### PR TITLE
Add streaming methods to parser and reflection API

### DIFF
--- a/dist/ProtoBuf.js
+++ b/dist/ProtoBuf.js
@@ -905,12 +905,18 @@
                 var method = {
                     "request": null,
                     "response": null,
+                    "request_stream": false,
+                    "response_stream": false,
                     "options": {}
                 };
                 token = this.tn.next();
                 if (token !== Lang.COPTOPEN)
                     throw Error("Illegal start of request type in service "+svc["name"]+"#"+name+" at line "+this.tn.line+": "+token);
                 token = this.tn.next();
+                if (token.toLowerCase() === "stream") {
+                  method["request_stream"] = true;
+                  token = this.tn.next();
+                }
                 if (!Lang.TYPEREF.test(token))
                     throw Error("Illegal request type in service "+svc["name"]+"#"+name+" at line "+this.tn.line+": "+token);
                 method["request"] = token;
@@ -924,6 +930,10 @@
                 if (token != Lang.COPTOPEN)
                     throw Error("Illegal start of response type in service "+svc["name"]+"#"+name+" at line "+this.tn.line+": "+token);
                 token = this.tn.next();
+                if (token.toLowerCase() === "stream") {
+                  method["response_stream"] = true;
+                  token = this.tn.next();
+                }
                 method["response"] = token;
                 token = this.tn.next();
                 if (token !== Lang.COPTCLOSE)
@@ -3602,7 +3612,8 @@
              * @constructor
              * @extends ProtoBuf.Reflect.Service.Method
              */
-            var RPCMethod = function(builder, svc, name, request, response, options) {
+            var RPCMethod = function(builder, svc, name, request, response, request_stream,
+                                     response_stream, options) {
                 Method.call(this, builder, svc, name, options);
 
                 /**
@@ -3623,6 +3634,20 @@
                  * @expose
                  */
                 this.responseName = response;
+
+                /**
+                 * Whether requests are streamed
+                 * @type {bool}
+                 * @expose
+                 */
+              this.requestStream = request_stream;
+
+                /**
+                 * Whether responses are streamed
+                 * @type {bool}
+                 * @expose
+                 */
+                this.responseStream = response_stream;
 
                 /**
                  * Resolved request message type.
@@ -3952,7 +3977,7 @@
                                 obj = new Reflect.Service(this, this.ptr, def["name"], def["options"]);
                                 for (i in def["rpc"])
                                     if (def["rpc"].hasOwnProperty(i))
-                                        obj.addChild(new Reflect.Service.RPCMethod(this, obj, i, def["rpc"][i]["request"], def["rpc"][i]["response"], def["rpc"][i]["options"]));
+                                        obj.addChild(new Reflect.Service.RPCMethod(this, obj, i, def["rpc"][i]["request"], def["rpc"][i]["response"], def["rpc"][i]["request_stream"], def["rpc"][i]["response_stream"], def["rpc"][i]["options"]));
                                 this.ptr.addChild(obj);
                                 obj = null;
                             } else if (Builder.isValidExtend(def)) {

--- a/dist/ProtoBuf.noparse.js
+++ b/dist/ProtoBuf.noparse.js
@@ -2692,7 +2692,8 @@
              * @constructor
              * @extends ProtoBuf.Reflect.Service.Method
              */
-            var RPCMethod = function(builder, svc, name, request, response, options) {
+            var RPCMethod = function(builder, svc, name, request, response, request_stream,
+                                     response_stream, options) {
                 Method.call(this, builder, svc, name, options);
 
                 /**
@@ -2713,6 +2714,20 @@
                  * @expose
                  */
                 this.responseName = response;
+
+                /**
+                 * Whether requests are streamed
+                 * @type {bool}
+                 * @expose
+                 */
+              this.requestStream = request_stream;
+
+                /**
+                 * Whether responses are streamed
+                 * @type {bool}
+                 * @expose
+                 */
+                this.responseStream = response_stream;
 
                 /**
                  * Resolved request message type.
@@ -3042,7 +3057,7 @@
                                 obj = new Reflect.Service(this, this.ptr, def["name"], def["options"]);
                                 for (i in def["rpc"])
                                     if (def["rpc"].hasOwnProperty(i))
-                                        obj.addChild(new Reflect.Service.RPCMethod(this, obj, i, def["rpc"][i]["request"], def["rpc"][i]["response"], def["rpc"][i]["options"]));
+                                        obj.addChild(new Reflect.Service.RPCMethod(this, obj, i, def["rpc"][i]["request"], def["rpc"][i]["response"], def["rpc"][i]["request_stream"], def["rpc"][i]["response_stream"], def["rpc"][i]["options"]));
                                 this.ptr.addChild(obj);
                                 obj = null;
                             } else if (Builder.isValidExtend(def)) {

--- a/src/ProtoBuf/Builder.js
+++ b/src/ProtoBuf/Builder.js
@@ -4,7 +4,7 @@
  */
 ProtoBuf.Builder = (function(ProtoBuf, Lang, Reflect) {
     "use strict";
-    
+
     /**
      * Constructs a new Builder.
      * @exports ProtoBuf.Builder
@@ -216,7 +216,7 @@ ProtoBuf.Builder = (function(ProtoBuf, Lang, Reflect) {
             defs = [defs];
         if (defs.length === 0)
             return this;
-        
+
         // It's quite hard to keep track of scopes and memory here, so let's do this iteratively.
         var stack = [];
         stack.push(defs); // One level [a, b, c]
@@ -298,7 +298,7 @@ ProtoBuf.Builder = (function(ProtoBuf, Lang, Reflect) {
                         obj = new Reflect.Service(this, this.ptr, def["name"], def["options"]);
                         for (i in def["rpc"])
                             if (def["rpc"].hasOwnProperty(i))
-                                obj.addChild(new Reflect.Service.RPCMethod(this, obj, i, def["rpc"][i]["request"], def["rpc"][i]["response"], def["rpc"][i]["options"]));
+                                obj.addChild(new Reflect.Service.RPCMethod(this, obj, i, def["rpc"][i]["request"], def["rpc"][i]["response"], def["rpc"][i]["request_stream"], def["rpc"][i]["response_stream"], def["rpc"][i]["options"]));
                         this.ptr.addChild(obj);
                         obj = null;
                     } else if (Builder.isValidExtend(def)) {
@@ -579,7 +579,7 @@ ProtoBuf.Builder = (function(ProtoBuf, Lang, Reflect) {
     // Exist for the sole purpose of being able to "... instanceof ProtoBuf.Builder.Message" etc.
     Builder.Message = function() {};
     Builder.Service = function() {};
-    
+
     return Builder;
-    
+
 })(ProtoBuf, ProtoBuf.Lang, ProtoBuf.Reflect);

--- a/src/ProtoBuf/DotProto/Parser.js
+++ b/src/ProtoBuf/DotProto/Parser.js
@@ -173,7 +173,7 @@ ParserPrototype._parsePackage = function(token) {
 /**
  * Parses an import definition.
  * @param {string} token Initial token
- * @return {string} Import file name 
+ * @return {string} Import file name
  * @throws {Error} If the import definition cannot be parsed
  * @private
  */
@@ -307,12 +307,18 @@ ParserPrototype._parseServiceRPC = function(svc, token) {
     var method = {
         "request": null,
         "response": null,
+        "request_stream": false,
+        "response_stream": false,
         "options": {}
     };
     token = this.tn.next();
     if (token !== Lang.COPTOPEN)
         throw Error("Illegal start of request type in service "+svc["name"]+"#"+name+" at line "+this.tn.line+": "+token);
     token = this.tn.next();
+    if (token.toLowerCase() === "stream") {
+      method["request_stream"] = true;
+      token = this.tn.next();
+    }
     if (!Lang.TYPEREF.test(token))
         throw Error("Illegal request type in service "+svc["name"]+"#"+name+" at line "+this.tn.line+": "+token);
     method["request"] = token;
@@ -326,6 +332,10 @@ ParserPrototype._parseServiceRPC = function(svc, token) {
     if (token != Lang.COPTOPEN)
         throw Error("Illegal start of response type in service "+svc["name"]+"#"+name+" at line "+this.tn.line+": "+token);
     token = this.tn.next();
+    if (token.toLowerCase() === "stream") {
+      method["response_stream"] = true;
+      token = this.tn.next();
+    }
     method["response"] = token;
     token = this.tn.next();
     if (token !== Lang.COPTCLOSE)

--- a/src/ProtoBuf/Reflect/Service/RPCMethod.js
+++ b/src/ProtoBuf/Reflect/Service/RPCMethod.js
@@ -10,7 +10,8 @@
  * @constructor
  * @extends ProtoBuf.Reflect.Service.Method
  */
-var RPCMethod = function(builder, svc, name, request, response, options) {
+var RPCMethod = function(builder, svc, name, request, response, request_stream,
+                         response_stream, options) {
     Method.call(this, builder, svc, name, options);
 
     /**
@@ -31,6 +32,20 @@ var RPCMethod = function(builder, svc, name, request, response, options) {
      * @expose
      */
     this.responseName = response;
+
+    /**
+     * Whether requests are streamed
+     * @type {bool}
+     * @expose
+     */
+  this.requestStream = request_stream;
+
+    /**
+     * Whether responses are streamed
+     * @type {bool}
+     * @expose
+     */
+    this.responseStream = response_stream;
 
     /**
      * Resolved request message type.

--- a/tests/suite.js
+++ b/tests/suite.js
@@ -22,16 +22,16 @@
 
     var FILE = "ProtoBuf.js";
     var BROWSER = !!global.window;
-    
+
     var ProtoBuf = BROWSER ? global.dcodeIO.ProtoBuf : require(__dirname+"/../dist/"+FILE),
         ByteBuffer = BROWSER ? global.dcodeIO.ByteBuffer : ByteBuffer || require("bytebuffer"),
         util = BROWSER ? null : require("util"),
         fs = BROWSER ? null : require("fs");
-        
+
         if (typeof __dirname == 'undefined') {
             __dirname = document.location.href.replace(/[\/\\][^\/\\]*$/, "");
         }
-    
+
     /**
      * Constructs a new Sandbox for module loaders and shim testing.
      * @param {Object.<string,*>} properties Additional properties to set
@@ -48,11 +48,11 @@
             }
         };
     };
-    
+
     function fail(e) {
         throw(e);
     }
-    
+
     /**
      * Validates the complexDotProto and complexInline tests.
      * @param {*} test Nodeunit test
@@ -62,7 +62,7 @@
         var Car = Game.Cars.Car,
             Vendor = Car.Vendor,
             Speed = Car.Speed;
-    
+
         var vendor;
         // Car from class with argument list properties
         var car = new Car(
@@ -91,13 +91,13 @@
         test.equal(carDec.vendor.address.country, "US");
         test.equal(carDec.vendor.address.country, carDec.getVendor().get_address().country);
     }
-    
+
     /**
      * Test suite.
      * @type {Object.<string,function>}
      */
     var suite = {
-    
+
         "init": function(test) {
             test.ok(typeof ProtoBuf == "object");
             test.ok(typeof ProtoBuf.Reflect == 'object');
@@ -141,13 +141,13 @@
                 test.equal(bb.flip().toString("debug"), "<08 98 01>");
                 var instDec = Test1.decode(bb);
                 test.equal(instDec.a, 152);
-                
+
             } catch (e) {
                 fail(e);
             }
             test.done();
         },
-    
+
         // Basically the same as example1, but with an unsigned value.
         "example1u": function(test) {
             try{
@@ -163,13 +163,13 @@
                 test.equal(bb.flip().toString("debug"), "<08 FF FF FF FF 0F>");
                 var instDec = Test1u.decode(bb);
                 test.strictEqual(instDec.a, 4294967295);
-                
+
             } catch (e) {
                 fail(e);
             }
             test.done();
         },
-        
+
         // Example "Strings" from the protobuf docs
         // https://developers.google.com/protocol-buffers/docs/encoding#types
         "example2": function(test) {
@@ -189,7 +189,7 @@
             }
             test.done();
         },
-        
+
         // Example "Embedded Messages" from the protobuf docs
         // https://developers.google.com/protocol-buffers/docs/encoding#embedded
         "example3": function(test) {
@@ -212,7 +212,7 @@
             }
             test.done();
         },
-        
+
         "example4": function(test) {
             try {
                 var builder = ProtoBuf.loadProtoFile(__dirname+"/example4.proto");
@@ -243,7 +243,7 @@
             }
             test.done();
         },
-    
+
         "numberFormats": function(test) {
             try {
                 var builder = ProtoBuf.loadProtoFile(__dirname+"/numberformats.proto");
@@ -262,7 +262,7 @@
             }
             test.done();
         },
-    
+
         // Check encode/decode against a table of known correct pairs.
         // Note that javascript ArrayBuffer does not support signed Zero or NaN
         // bertdouglas (https://github.com/bertdouglas)
@@ -274,7 +274,7 @@
                 var builder = ProtoBuf.loadProto(str_proto);
                 var root = builder.build();
                 var Float = root.Float;
-    
+
                 var in_tolerance = function (reference,actual) {
                     var tol = 1e-6;
                     var scale = 1.0;
@@ -284,7 +284,7 @@
                     var err = Math.abs(reference - actual)/scale;
                     return err < tol;
                 };
-    
+
                 var f_vals = [
                     // hex values are shown here in big-endian following IEEE754 notation
                     // protobuf is little-endian
@@ -307,7 +307,7 @@
                     // { f: -NaN , b: "FF C0 00 00>" },
                     // { f: +NaN , b: "7F C0 00 00" }
                 ];
-    
+
                 f_vals.map( function(x) {
                     // check encode
                     var m1 = new Float();
@@ -316,7 +316,7 @@
                     m1.encode(b1);
                     var q1 = b1.slice(1,5).compact().reverse();
                     test.strictEqual('<' + x.b + '>', q1.toString("debug"));
-    
+
                     // check decode
                     var b2 = new ByteBuffer();
                     var s1 = x.b + ' 0D';
@@ -327,7 +327,7 @@
                     b2.limit = b2.offset;
                     b2.offset = 0;
                     var m2 = Float.decode(b2);
-    
+
                     var s4 = "" + x.f +" " + m2.f;
                     if ( isNaN(x.f) ) {
                         test.ok( isNaN(m2.f), s4 );
@@ -344,7 +344,7 @@
             }
             test.done();
         },
-        
+
         "bytes": function(test) {
             try {
                 var str_proto = "message Test { required bytes b = 1; }";
@@ -382,7 +382,7 @@
             }
             test.done();
         },
-        
+
         "notEnoughBytes": function(test) {
             var builder = ProtoBuf.loadProto("message Test { required bytes b = 1; }");
             var Test = builder.build("Test");
@@ -444,7 +444,7 @@
             }
             test.done();
         },
-        
+
         "emptyDefaultString": function(test) {
             try {
                 var builder = ProtoBuf.loadProto("message Test1 { required string test = 1 [default = \"\"]; }");
@@ -459,7 +459,7 @@
             }
             test.done();
         },
-        
+
         "trailingSemicolon": function(test) {
             try {
                 var builder = ProtoBuf.loadProto("message Test1 { optional string test = 1; };");
@@ -471,7 +471,7 @@
             }
             test.done();
         },
-        
+
         "inner": {
 
             "longstr": function(test) {
@@ -526,9 +526,9 @@
                 }
                 test.done();
             }
-            
+
         },
-        
+
         "truncated": function(test) {
             try {
                 var builder = ProtoBuf.loadProto("message Test { required int32 a = 1; required int32 b = 2; }");
@@ -559,10 +559,10 @@
             }
             test.done();
         },
-        
+
         // Options on all levels
         "options": {
-            
+
             "parse": function(test) {
                 try {
                     var parser = new ProtoBuf.DotProto.Parser(ProtoBuf.Util.fetch(__dirname+"/options.proto"));
@@ -577,7 +577,7 @@
                 }
                 test.done();
             },
-            
+
             "export": function(test) {
                 try {
                     var builder = ProtoBuf.loadProtoFile(__dirname+"/options.proto");
@@ -597,7 +597,7 @@
                 test.done();
             }
         },
-        
+
         // Comments
         "comments": function(test) {
             try {
@@ -613,7 +613,7 @@
             }
             test.done();
         },
-    
+
         // A more or less complex proto with type references
         "complexProto": function(test) {
             try {
@@ -626,7 +626,7 @@
             }
             test.done();
         },
-        
+
         // The same created without calling upon the parser to do so (noparse)
         "complexJSON": function(test) {
             try {
@@ -637,7 +637,7 @@
             }
             test.done();
         },
-        
+
         // Builder reused to add definitions from multiple sources
         "multiBuilder": function(test) {
             try {
@@ -651,7 +651,7 @@
             }
             test.done();
         },
-        
+
         // Inner messages test
         "inner": function(test) {
             try {
@@ -684,7 +684,7 @@
             }
             test.done();
         },
-        
+
         // Packed vs. not packed repeated fields test
         "packed": function(test) {
             try {
@@ -776,7 +776,7 @@
             }
             test.done();
         },
-        
+
         "x64Fixed": function(test) {
             try {
                 var builder = ProtoBuf.loadProtoFile(__dirname+"/x64.proto");
@@ -808,7 +808,7 @@
             }
             test.done();
         },
-    
+
         "x64Varint": function(test) {
             try {
                 var builder = ProtoBuf.loadProtoFile(__dirname+"/x64.proto");
@@ -824,7 +824,7 @@
                 test.ok(myTest.sval instanceof ByteBuffer.Long);
                 test.equal(myTest.sval.unsigned, false);
                 test.equal(myTest.sval.toNumber(), -2);
-    
+
                 myTest.setVal(-2);
                 myTest.setUval(2);
                 myTest.setSval(-3);
@@ -863,7 +863,7 @@
             }
             test.done();
         },
-        
+
         "imports": function(test) {
             try {
                 var builder = ProtoBuf.loadProtoFile(__dirname+"/imports.proto");
@@ -899,7 +899,7 @@
             test.strictEqual(inst[".y.second_val"], null);
             test.done();
         },
-        
+
         "toplevel": function(test) {
             try {
                 var builder = ProtoBuf.loadProtoFile(__dirname+"/toplevel.proto");
@@ -915,7 +915,7 @@
             }
             test.done();
         },
-        
+
         "importsToplevel": function(test) {
             try {
                 var builder = ProtoBuf.loadProtoFile(__dirname+"/imports-toplevel.proto");
@@ -932,7 +932,7 @@
             }
             test.done();
         },
-        
+
         "importDuplicate": function(test) {
             try {
                 var builder = ProtoBuf.loadProtoFile(__dirname+"/import_a.proto");
@@ -942,7 +942,7 @@
                 var root = builder.build();
                 test.ok(root.A);
                 test.ok(root.B);
-                test.ok(root.Common);                
+                test.ok(root.Common);
             } catch (e) {
                 fail(e);
             }
@@ -960,14 +960,14 @@
                 var rootB = builderB.build();
                 test.ok(rootA.A);
                 test.ok(rootB.B);
-                test.ok(rootA.Common);                
-                test.ok(rootB.Common);                
+                test.ok(rootA.Common);
+                test.ok(rootB.Common);
             } catch (e) {
                 fail(e);
             }
             test.done();
         },
-        
+
         "importRoot": function(test) {
             try {
                 var builder = ProtoBuf.loadProtoFile({
@@ -981,7 +981,7 @@
             }
             test.done();
         },
-        
+
         "extend": function(test) {
             try {
                 var ast = new ProtoBuf.DotProto.Parser(fs.readFileSync(__dirname+"/extend.proto")).parse();
@@ -1130,7 +1130,7 @@
             }
             test.done();
         },
-        
+
         "services": function(test) {
             try {
                 var parser = new ProtoBuf.DotProto.Parser(ProtoBuf.Util.fetch(__dirname+"/custom-options.proto"));
@@ -1141,6 +1141,8 @@
                         "MyMethod": {
                             "request": "RequestType",
                             "response": "ResponseType",
+                            "request_stream": false,
+                            "response_stream": false,
                             "options": {
                                 "(my_method_option).foo": 567,
                                 "(my_method_option).bar": "Some string"
@@ -1151,14 +1153,14 @@
                         "(my_service_option)": "FOO"
                     }
                 }]);
-                
+
                 var builder = ProtoBuf.loadProtoFile(__dirname+"/custom-options.proto");
                 var root = builder.build(),
                     MyService = root.MyService,
                     RequestType = root.RequestType,
                     ResponseType = root.ResponseType,
                     called = false;
-                
+
                 test.deepEqual(MyService.$options, {
                     "(my_service_option)": "FOO"
                 });
@@ -1166,20 +1168,20 @@
                     "(my_method_option).foo": 567,
                     "(my_method_option).bar": "Some string"
                 });
-                
+
                 // Provide the service with your actual RPC implementation based on whatever framework you like most.
                 var myService = new MyService(function(method, req, callback) {
                     test.strictEqual(method, ".MyService.MyMethod");
                     test.ok(req instanceof RequestType);
                     called = true;
-                    
+
                     // In this case we just return no error and our pre-built response. This must be properly async!
                     setTimeout(callback.bind(this, null, (new ResponseType()).encode() /* as raw bytes for debugging */ ));
                 });
-                
+
                 test.deepEqual(myService.$options, MyService.$options);
                 test.deepEqual(myService.MyMethod.$options, MyService.MyMethod.$options);
-                
+
                 // Call the service with your request message and provide a callback. This will call your actual service
                 // implementation to perform the request and gather a response before calling the callback. If the
                 // request or response type is invalid i.e. not an instance of RequestType or ResponseType, your
@@ -1198,7 +1200,7 @@
                 fail(e);
             }
         },
-        
+
         // Properly ignore "syntax" and "extensions" keywords
         "gtfs-realtime": function(test) {
             try {
@@ -1210,7 +1212,7 @@
             }
             test.done();
         },
-        
+
         "delimited": function(test) {
             try {
                 var builder = ProtoBuf.loadProto("message Position { required int32 x = 1; required int32 y = 2; }");
@@ -1231,7 +1233,7 @@
             }
             test.done();
         },
-        
+
         "stringify": function(test) {
             try {
                 var builder = ProtoBuf.loadProto("message Position { required int32 x = 1; required int64 y = 2; }");
@@ -1252,7 +1254,7 @@
             }
             test.done();
         },
-        
+
         "fields": function(test) {
             try {
                 var builder = ProtoBuf.loadProtoFile(__dirname+"/optional.proto");
@@ -1269,7 +1271,7 @@
             }
             test.done();
         },
-        
+
         "fieldsToCamelCase": function(test) {
             try {
                 ProtoBuf.convertFieldsToCamelCase = true;
@@ -1290,14 +1292,14 @@
                 test.strictEqual(msg.a_field, null);
                 test.equal(TTest.getChild("aField").id, 3);
                 test.equal(TTest.getChild("a_field").id, 4);
-                
+
                 // No collision
                 test.strictEqual(msg.itsAField, null);
                 test.equal(TTest.getChild("itsAField").id, 5);
-                
+
                 test.ok(typeof msg.set_its_a_field === "function");
                 test.ok(typeof msg.setItsAField === "function");
-                
+
                 ProtoBuf.convertFieldsToCamelCase = false;
             } catch (e) {
                 ProtoBuf.convertFieldsToCamelCase = false;
@@ -1305,7 +1307,7 @@
             }
             test.done();
         },
-        
+
         "setarray": function(test) {
             try {
                 var builder = ProtoBuf.loadProtoFile(__dirname+"/setarray.proto");
@@ -1313,13 +1315,13 @@
                     Outer = root.Outer,
                     Inner = root.Inner,
                     inners = [];
-                
+
                 // Array of repeated messages
                 inners.push(new Inner("a"), new Inner("b"), new Inner("c"));
                 var outer = new Outer();
                 outer.setInners(inners);
                 test.deepEqual(outer.inners, inners);
-                
+
                 // Array of repeated message objects
                 inners = [];
                 inners.push({ str: 'a' }, { str: 'b' }, { str: 'c' });
@@ -1351,7 +1353,7 @@
             }
             test.done();
         },
-        
+
         "negInt32": function(test) {
             try {
                 var builder = ProtoBuf.loadProto("message Test { required int32 value = 2; }");
@@ -1368,7 +1370,7 @@
             }
             test.done();
         },
-        
+
         "negEnumId": function(test) {
             try {
                 test.doesNotThrow(function() {
@@ -1382,13 +1384,13 @@
                     test.strictEqual(bb.remaining(), size);
                     t = Test.decode(bb);
                     test.strictEqual(t.type, -1);
-                });                
+                });
             } catch (e) {
                 fail(e);
             }
             test.done();
         },
-        
+
         "base64": function(test) {
             try {
                 var Message = ProtoBuf.loadProto("message Message { required string s = 1; }").build("Message");
@@ -1404,7 +1406,7 @@
             }
             test.done();
         },
-        
+
         "hex": function(test) {
             try {
                 var Message = ProtoBuf.loadProto("message Message { required string s = 1; }").build("Message");
@@ -1436,7 +1438,7 @@
             }
             test.done();
         },
-        
+
         "tokenizerLine": function(test) {
             try {
                 var parser = new ProtoBuf.DotProto.Parser("package test;\n\nmessage Message {\n\trequired string invalid = 1;}ERROR\n"),
@@ -1488,7 +1490,7 @@
             }
             test.done();
         },
-        
+
         "toRaw": function(test) {
             try {
                 var builder = ProtoBuf.loadProto("message MyMessage { required int32 a = 1; required int32 b = 2; required bytes c = 3; }"),
@@ -1529,7 +1531,7 @@
             }
             test.done();
         },
-        
+
         "importStringSuccessively": function(test) {
             try {
                 var proto1 = "message A { required string a = 1; };";
@@ -1558,7 +1560,7 @@
             }
             test.done();
         },
-        
+
         "packable": function(test) {
             try {
                 var proto = 'message Inner { required int32 id=2; }\nmessage Outer { repeated Inner inner = 1 [packed=true]; }';
@@ -1579,7 +1581,7 @@
             }
             test.done();
         },
-        
+
         "$type": function(test) {
             var builder = ProtoBuf.loadProto("message Test {}");
             var Test = builder.build("Test"),
@@ -1587,7 +1589,7 @@
             test.strictEqual(new Test().$type, TTest);
             test.done();
         },
-        
+
         "descriptor": function(test) {
             try {
                 var proto = 'import "./google/protobuf/descriptor.proto";';
@@ -1634,12 +1636,12 @@
 
         // Node.js only
         "loaders": BROWSER ? {} : {
-            
+
             "commonjs": function(test) {
                 var fs = require("fs")
                   , vm = require("vm")
                   , util = require('util');
-        
+
                 var code = fs.readFileSync(__dirname+"/../dist/"+FILE);
                 var exports = {};
                 var sandbox = new Sandbox({
@@ -1663,12 +1665,12 @@
                 test.ok(typeof sandbox.require != 'undefined' && sandbox.require.called);
                 test.done();
             },
-        
+
             "amd": function(test) {
                 var fs = require("fs")
                   , vm = require("vm")
                   , util = require('util');
-        
+
                 var code = fs.readFileSync(__dirname+"/../dist/"+FILE);
                 var sandbox = new Sandbox({
                     define: (function() {
@@ -1685,12 +1687,12 @@
                 test.ok(sandbox.define.called == true);
                 test.done();
             },
-        
+
             "shim": function(test) {
                 var fs = require("fs")
                   , vm = require("vm")
                   , util = require('util');
-        
+
                 var code = fs.readFileSync(__dirname+"/../dist/"+FILE);
                 var sandbox = new Sandbox({
                     dcodeIO: {
@@ -1704,7 +1706,7 @@
             }
         }
     };
-    
+
     if (typeof module != 'undefined' && module.exports) {
         module.exports = suite;
     } else {


### PR DESCRIPTION
Add the ability to parse streaming requests and responses and expose that information in the reflection API. This is one of the changes needed to support [Protocol Buffers v3](https://github.com/google/protobuf/releases/tag/v3.0.0-alpha-1).