### PR TITLE
Change ProtoBuf.Builder.Message#toRaw to return bytes fields as buffers by default

### DIFF
--- a/src/ProtoBuf/Builder/Message.js
+++ b/src/ProtoBuf/Builder/Message.js
@@ -456,7 +456,7 @@ MessagePrototype.toHex = MessagePrototype.encodeHex;
 /**
  * Clones a message object to a raw object.
  * @param {*} obj Object to clone
- * @param {boolean} includeBinaryAsBase64 Whether to include binary data as base64 strings or not
+ * @param {boolean} includeBinaryAsBase64 Whether to include binary data as base64 strings instead of Buffers
  * @returns {*} Cloned object
  * @inner
  */
@@ -467,8 +467,11 @@ function cloneRaw(obj, includeBinaryAsBase64) {
             if (obj[i] === null || typeof obj[i] !== 'object')
                 clone[i] = obj[i];
             else if (obj[i] instanceof ByteBuffer) {
-                if (includeBinaryAsBase64)
+                if (includeBinaryAsBase64) {
                     clone[i] = obj[i].toBase64();
+                } else {
+                    clone[i] = obj[i].toBuffer();
+                }
             } else // is a non-null object
                 clone[i] = cloneRaw(obj[i], includeBinaryAsBase64);
         }
@@ -477,7 +480,7 @@ function cloneRaw(obj, includeBinaryAsBase64) {
 
 /**
  * Returns the message's raw payload.
- * @param {boolean=} includeBinaryAsBase64 Whether to include binary data as base64 strings or not, defaults to `false`
+ * @param {boolean=} includeBinaryAsBase64 Whether to include binary data as base64 strings instead of Buffers, defaults to `false`
  * @returns {Object.<string,*>} Raw payload
  * @expose
  */


### PR DESCRIPTION
Instead of silently dropping bytes fields, `Message#toRaw` should return them as byte sequence objects. `ByteBuffer#toBuffer` returns different buffer types depending on platform, so this will work on Node and browser. It also either returns a reference to the backing buffer or a slice of it, so this is both fast and memory-efficient.