### PR TITLE
Makes pb2js handle repeated fields properly.

### DIFF
--- a/cli/pbjs/targets/json.js
+++ b/cli/pbjs/targets/json.js
@@ -175,8 +175,9 @@ function buildMessage(msg) {
  * @returns {!*}
  */
 function buildMessageField(fld) {
+    var fieldType = fld.repeated ? "repeated" : (fld.required ? "required" : "optional");
     return {
-        "rule"    : fld.required ? "required" : "optional",
+        "rule"    : fieldType,
         "type"    : fld.resolvedType ? fld.parent.qn(fld.resolvedType) : fld.type['name'],
         "name"    : fld instanceof ProtoBuf.Reflect.Message.ExtensionField ? fld.name.substring(fld.name.lastIndexOf(".")+1): fld.name,
         "id"      : fld.id,

--- a/tests/complex.json
+++ b/tests/complex.json
@@ -41,6 +41,12 @@
                             "type": "Address",
                             "name": "address",
                             "id": 2
+                        },
+                        {
+                            "rule": "repeated",
+                            "type": "string",
+                            "name": "models",
+                            "id": 3
                         }
                     ],
                     "messages": [

--- a/tests/complex.proto
+++ b/tests/complex.proto
@@ -13,6 +13,7 @@ message Car {
         }
         
         optional Address address = 2;
+        repeated string models = 3;               // The models sold here.
     }
     
     required  string  model  = 1;                 // Model name

--- a/tests/suite.js
+++ b/tests/suite.js
@@ -73,7 +73,8 @@
                 // Address from object
                 "address": {
                     "country": "US"
-                }
+                },
+                "models": ["m1"]
             }),
             // Speed from enum object
             Speed.SUPERFAST
@@ -82,14 +83,15 @@
         test.equal(car.vendor.name, "Iron Inc.");
         test.equal(car.vendor.address.country, "US");
         test.equal(car.vendor.address.country, car.getVendor().get_address().country);
-        var bb = new ByteBuffer(28);
+        var bb = new ByteBuffer(32);
         car.encode(bb);
-        test.equal(bb.flip().toString("debug"), "<0A 05 52 75 73 74 79 12 11 0A 09 49 72 6F 6E 20 49 6E 63 2E 12 04 0A 02 55 53 18 02>");
+        test.equal(bb.flip().toString("debug"), "<0A 05 52 75 73 74 79 12 15 0A 09 49 72 6F 6E 20 49 6E 63 2E 12 04 0A 02 55 53 1A 02 6D 31 18 02>");
         var carDec = Car.decode(bb);
         test.equal(carDec.model, "Rusty");
         test.equal(carDec.vendor.name, "Iron Inc.");
         test.equal(carDec.vendor.address.country, "US");
         test.equal(carDec.vendor.address.country, carDec.getVendor().get_address().country);
+        test.equal(carDec.vendor.models[0], "m1");
     }
 
     /**


### PR DESCRIPTION
Adds a field to complex.proto to ensure we can instantiate an object
that includes repeated fields.  Also updates the encoded string checked
in the test but I didn't really verify it against another protobuf
implementation or by hand (though the test does pass).

Fixes #222