### PR TITLE
don't set default fields on decode

### DIFF
--- a/src/ProtoBuf/Reflect/Message.js
+++ b/src/ProtoBuf/Reflect/Message.js
@@ -271,8 +271,7 @@ MessagePrototype.decode = function(buffer, length, expectedGroupEndId) {
                 var err = Error("Missing at least one required field for "+this.toString(true)+": "+field.name);
                 err["decoded"] = msg; // Still expose what we got
                 throw(err);
-            } else if (field.defaultValue !== null)
-                msg[field.name] = field.defaultValue;
+            }
     }
     return msg;
 };

--- a/tests/suite.js
+++ b/tests/suite.js
@@ -420,7 +420,7 @@
                 t.setOk(false);
                 test.strictEqual(t.ok, false);
                 t.setOk(null); // Not set
-                test.strictEqual(Test.decode(t.encode()).ok, false); // = default when missing
+                test.strictEqual(Test.decode(t.encode()).ok, null); // = not set when missing
             } catch (err) {
                 fail(err);
             }


### PR DESCRIPTION
Ideally, decoding a message does not change the message.

By setting default fields, the output buffer will be different when re-encoded. Certain protocols (https://github.com/bitcoin/bips/blob/master/bip-0070.mediawiki#paymentdetailspaymentrequest) rely on being able to decode a protobuf, change one field, then re-encode to get the original signed data.