### PR TITLE
Convert cli to use yargs

### DIFF
--- a/cli/pbjs.js
+++ b/cli/pbjs.js
@@ -174,11 +174,11 @@ pbjs.main = function(argv) {
         })
         .check(function (args) {
             if (args.source && Object.keys(pbjs.sources).indexOf(args.source) === -1) {
-                return "Unrecognized source format.";
+                return "Unrecognized source format: '" + args.source + "'";
             }
 
             if (args.target && Object.keys(pbjs.targets).indexOf(args.target) === -1) {
-                return "Unrecognized target format.";
+                return "Unrecognized target format: '" + args.target + "'";
             }
 
             if (args._.length < 3) {

--- a/cli/pbjs.js
+++ b/cli/pbjs.js
@@ -173,11 +173,11 @@ pbjs.main = function(argv) {
             }
         })
         .check(function (args) {
-            if (args.source && Object.keys(pbjs.sources).indexOf(args.source) === -1) {
+            if (args.source && typeof pbjs.sources[args.source] !== "function") {
                 return "Unrecognized source format: '" + args.source + "'";
             }
 
-            if (args.target && Object.keys(pbjs.targets).indexOf(args.target) === -1) {
+            if (args.target && typeof pbjs.targets[args.target] !== "function") {
                 return "Unrecognized target format: '" + args.target + "'";
             }
 
@@ -211,20 +211,6 @@ pbjs.main = function(argv) {
             options.source = "json";
         else
             options.source = "proto";
-    }
-    if (!pbjs.sources.hasOwnProperty(options.source) || typeof pbjs.sources[options.source] !== 'function') {
-        if (!options.quiet)
-            cli.fail("No such source format: "+options.source);
-        return pbjs.STATUS_ERR_SOURCE_FORMAT;
-    }
-
-    // Set default target format if not specified, then verify
-    if (typeof options.target !== 'string')
-        options.target = "json";
-    if (!pbjs.targets.hasOwnProperty(options.target) || typeof pbjs.targets[options.target] !== 'function') {
-        if (!options.quiet)
-            cli.fail("No such target format: "+options.target);
-        return pbjs.STATUS_ERR_TARGET_FORMAT;
     }
 
     // Load the source file to a builder

--- a/package.json
+++ b/package.json
@@ -17,10 +17,12 @@
     "bugs": {
         "url": "https://github.com/dcodeIO/ProtoBuf.js/issues"
     },
+    "homepage": "https://github.com/dcodeIO/ProtoBuf.js",
     "keywords": ["net", "buffer", "protobuf", "serialization", "bytebuffer", "websocket", "webrtc"],
     "dependencies": {
         "bytebuffer": "~3 >=3.5",
-        "ascli": "~1"
+        "ascli": "~1",
+        "yargs": "^3.10.0"
     },
     "devDependencies": {
         "testjs": "~1 >=1.0.4",

--- a/package.json
+++ b/package.json
@@ -37,10 +37,10 @@
     },
     "scripts": {
         "prepublish": "npm test",
-        "test": "node bin/pbjs tests/complex.proto -target=json > tests/complex.json && node node_modules/testjs/bin/testjs tests/suite.js",
+        "test": "node bin/pbjs tests/complex.proto --target=json > tests/complex.json && node node_modules/testjs/bin/testjs tests/suite.js",
         "make": "npm run-script build && npm run-script compile && npm run-script descriptor2json && npm run-script compress && npm test && npm run-script jsdoc",
         "build": "node scripts/build.js",
-        "descriptor2json": "node bin/pbjs src/google/protobuf/descriptor.proto -target=json > src/google/protobuf/descriptor.json",
+        "descriptor2json": "node bin/pbjs src/google/protobuf/descriptor.proto --target=json > src/google/protobuf/descriptor.json",
         "compile": "npm run-script compile-full && npm run-script compile-noparse",
         "compile-full": "ccjs dist/ProtoBuf.js --create_source_map=dist/ProtoBuf.min.map --compilation_level=SIMPLE_OPTIMIZATIONS > dist/ProtoBuf.min.js",
         "compile-noparse": "ccjs dist/ProtoBuf.noparse.js --create_source_map=dist/ProtoBuf.noparse.min.map --compilation_level=SIMPLE_OPTIMIZATIONS > dist/ProtoBuf.noparse.min.js",

--- a/tests/suite.js
+++ b/tests/suite.js
@@ -982,7 +982,7 @@
             try {
                 // Suppress logging result to stdout
                 fixture.capture(function() { return false;});
-                require(__dirname+"/../cli/pbjs.js").main(["node", "bin/pbjs", __dirname+"/dupimport/main.proto", "-quiet"]);
+                require(__dirname+"/../cli/pbjs.js").main(["node", "bin/pbjs", __dirname+"/dupimport/main.proto", "--quiet"]);
                 fixture.release();
             } catch (e) {
                 fixture.release();
@@ -994,7 +994,7 @@
         "field_name_same_as_package": function(test) {
             try {
                 fixture.capture(function() { return false;});
-                require(__dirname+"/../cli/pbjs.js").main(["node", "bin/pbjs", __dirname+"/field_name_same_as_package/main.proto", "-quiet"]);
+                require(__dirname+"/../cli/pbjs.js").main(["node", "bin/pbjs", __dirname+"/field_name_same_as_package/main.proto", "--quiet"]);
                 fixture.release();
             } catch (e) {
                 fixture.release();


### PR DESCRIPTION
Fixes #277.

The help output isn't quite *as* pretty as it was before, but it is pretty close:

```
$ ./bin/pbjs --help

 _ |_ . _
|_)|_)|_)           ProtoBuf.js v4.0.0-b3 https://github.com/dcodeIO/ProtoBuf.js
|     '

CLI utility to convert between .proto and JSON syntax / to generate classes.
Usage: pbjs <filename> [options] [> outFile]


Options:
  --help            Show help  [boolean]
  --version         Show version number  [boolean]
  --source, -s      Specifies the source format. Valid formats are:
                        json         Plain JSON descriptor
                        proto        Plain .proto descriptor
  --target, -t      Specifies the target format. Valid formats are:
                        amd          Runtime structures as AMD module
                        commonjs     Runtime structures as CommonJS module
                        js           Runtime structures
                        json         Plain JSON descriptor
                        proto        Plain .proto descriptor  [default: "json"]
  --using, -u       Specifies an option to apply to the volatile builder
                    loading the source, e.g. convertFieldsToCamelCase.
  --min, -m         Minifies the output.  [default: false]
  --path, -p        Adds a directory to the include path.
  --legacy, -l      Includes legacy descriptors from google/protobuf/ if
                    explicitly referenced.  [default: false]
  --quiet, -q       Suppresses any informatory output to stderr.  [default: false]
  --use, -i         Specifies an option to apply to the emitted builder
                    utilized by your program, e.g. populateAccessors.
  --exports, -e     Specifies the namespace to export. Defaults to export
                    the root namespace.
  --dependency, -d  Library dependency to use when generating classes.
                    Defaults to 'protobufjs' for CommonJS, 'ProtoBuf' for
                    AMD modules and 'dcodeIO.ProtoBuf' for classes.
```

(it is still colored)