### PR TITLE
Fixed duplicate import errors on Windows

### DIFF
--- a/dist/ProtoBuf-light.js
+++ b/dist/ProtoBuf-light.js
@@ -3710,7 +3710,9 @@
                 var root = filename.root
                 if (ProtoBuf.Util.IS_NODE)
                     root = require("path")['resolve'](root);
-                var fname = [root, filename.file].join('/');
+                var delim = '/';
+                if (root.indexOf("\\") >= 0 || filename.file.indexOf("\\") >= 0) delim = '\\';
+                var fname = [root, filename.file].join(delim);
                 if (this.files[fname] === true) {
                   this.reset();
                   return this; // Skip duplicate imports

--- a/dist/ProtoBuf.js
+++ b/dist/ProtoBuf.js
@@ -4705,7 +4705,9 @@
                 var root = filename.root
                 if (ProtoBuf.Util.IS_NODE)
                     root = require("path")['resolve'](root);
-                var fname = [root, filename.file].join('/');
+                var delim = '/';
+                if (root.indexOf("\\") >= 0 || filename.file.indexOf("\\") >= 0) delim = '\\';
+                var fname = [root, filename.file].join(delim);
                 if (this.files[fname] === true) {
                   this.reset();
                   return this; // Skip duplicate imports

--- a/src/ProtoBuf/Builder.js
+++ b/src/ProtoBuf/Builder.js
@@ -415,7 +415,9 @@ ProtoBuf.Builder = (function(ProtoBuf, Lang, Reflect) {
             var root = filename.root
             if (ProtoBuf.Util.IS_NODE)
                 root = require("path")['resolve'](root);
-            var fname = [root, filename.file].join('/');
+            var delim = '/';
+            if (root.indexOf("\\") >= 0 || filename.file.indexOf("\\") >= 0) delim = '\\';
+            var fname = [root, filename.file].join(delim);
             if (this.files[fname] === true) {
               this.reset();
               return this; // Skip duplicate imports


### PR DESCRIPTION
If the import root is overridden on Windows, .proto files would be imported multiple times because the same file would appear with slashes both ways: root/file.proto and root\file.proto

This code fixes it the same way as it is similarly resolved a couple of lines below.

I don't see a CONTRIBUTING document anywhere, so please tell me if I wasn't supposed to run the build or was supposed to write a test for the code. 