### PR TITLE
fix #225 ignore fs for browser builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,9 @@
   "engines": {
     "node": ">=0.8"
   },
+  "browser": {
+   "fs": false
+  },
   "scripts": {
     "prepublish": "npm test",
     "test": "node bin/pbjs tests/complex.proto --target=json > tests/complex.json && node node_modules/testjs/bin/testjs tests/suite.js",


### PR DESCRIPTION
The browser builds (webpack, browserify) shouldn't attempt to require and inline the unreachable `require('fs')`.