### PR TITLE
fixed: Message.toRaw() Conversion long integer type "high" is zero.

### DIFF
--- a/src/ProtoBuf/Builder/Message.js
+++ b/src/ProtoBuf/Builder/Message.js
@@ -498,7 +498,7 @@ function cloneRaw(obj, binaryAsBase64, longsAsStrings, resolvedType) {
         return binaryAsBase64 ? obj.toBase64() : obj.toBuffer();
     // Convert Longs to proper objects or strings
     if (ProtoBuf.Long.isLong(obj))
-        return longsAsStrings ? obj.toString() : new ProtoBuf.Long(obj);
+        return longsAsStrings ? obj.toString() : ProtoBuf.Long.fromValue(obj);
     var clone;
     // Clone arrays
     if (Array.isArray(obj)) {


### PR DESCRIPTION
test case:

```js
var ProtoBuf = require('protobufjs');
var prototext = String(function() {
/*
package bigint;

message Value {
  oneof type {
    int64 int64 = 1;
    uint64 uint64 = 2;
  }
}
*/
}).match(/\/\*([^]*)\*\//)[1];

var builder = ProtoBuf.loadProto(prototext);
var messageValue = builder.build('bigint.Value');

var value = new messageValue({
  int64: ProtoBuf.ByteBuffer.Long.fromString("-192377746236123")
});
console.log('value: %j', value);
console.log('value.toRaw(): %j', value.toRaw());
```

output:
```bash
value: {"type":"int64","int64":{"low":-1866080987,"high":-44792,"unsigned":false},"uint64":null}
value.toRaw(): {"type":"int64","int64":{"low":-1866080987,"high":0,"unsigned":false},"uint64":null}
```

change:
`new ProtoBuf.Long(obj) -> ProtoBuf.Long.fromValue(obj)`

see: https://github.com/dcodeIO/long.js/blob/master/src/long.js
```js
function Long(low, high, unsigned) {}
```
