### PR TITLE
add out to file support for pbjs

### DIFF
--- a/cli/pbjs.js
+++ b/cli/pbjs.js
@@ -160,6 +160,10 @@ pbjs.main = function(argv) {
                 describe: "Suppresses any informatory output to stderr.",
                 default: false
             },
+            out: {
+                alias: "o",
+                describe: "Send output to file instead of stdout.",
+            },
             use: {
                 alias: "i",
                 describe: "Specifies an option to apply to the emitted builder\nutilized by your program, e.g. populateAccessors.",
@@ -265,6 +269,9 @@ pbjs.main = function(argv) {
     if (!options.quiet)
         cli.error("\nProcessing: "+sourceFiles.join(", ")+" ...\n");
     var res = pbjs.targets[options.target](builder, options);
+    if (options.out){
+        fs.writeFileSync(options.out, res);
+    }else
     process.stdout.write(res);
     if (!options.quiet)
         cli.error(""),


### PR DESCRIPTION
This can be helpful if pbjs is run in some case there's no way to use stdout redirect