### PR TITLE
avoid so many fn.bind calls

### DIFF
--- a/dist/protobuf-light.js
+++ b/dist/protobuf-light.js
@@ -888,9 +888,10 @@
          * @expose
          */
         ElementPrototype.verifyValue = function(value) {
+            var self = this;
             var fail = function(val, msg) {
-                throw Error("Illegal value for "+this.toString(true)+" of type "+this.type.name+": "+val+" ("+msg+")");
-            }.bind(this);
+                throw Error("Illegal value for "+self.toString(true)+" of type "+this.type.name+": "+val+" ("+msg+")");
+            };
             switch (this.type) {
                 // Signed 32bit
                 case ProtoBuf.TYPES["int32"]:
@@ -2521,9 +2522,10 @@
          */
         FieldPrototype.verifyValue = function(value, skipRepeated) {
             skipRepeated = skipRepeated || false;
+            var self = this;
             var fail = function(val, msg) {
-                throw Error("Illegal value for "+this.toString(true)+" of type "+this.type.name+": "+val+" ("+msg+")");
-            }.bind(this);
+                throw Error("Illegal value for "+self.toString(true)+" of type "+this.type.name+": "+val+" ("+msg+")");
+            };
             if (value === null) { // NULL values for optional fields
                 if (this.required)
                     fail(typeof value, "required");

--- a/dist/protobuf.js
+++ b/dist/protobuf.js
@@ -1794,9 +1794,10 @@
          * @expose
          */
         ElementPrototype.verifyValue = function(value) {
+            var self = this;
             var fail = function(val, msg) {
-                throw Error("Illegal value for "+this.toString(true)+" of type "+this.type.name+": "+val+" ("+msg+")");
-            }.bind(this);
+                throw Error("Illegal value for "+self.toString(true)+" of type "+this.type.name+": "+val+" ("+msg+")");
+            };
             switch (this.type) {
                 // Signed 32bit
                 case ProtoBuf.TYPES["int32"]:
@@ -3427,9 +3428,10 @@
          */
         FieldPrototype.verifyValue = function(value, skipRepeated) {
             skipRepeated = skipRepeated || false;
+            var self = this;
             var fail = function(val, msg) {
-                throw Error("Illegal value for "+this.toString(true)+" of type "+this.type.name+": "+val+" ("+msg+")");
-            }.bind(this);
+                throw Error("Illegal value for "+self.toString(true)+" of type "+this.type.name+": "+val+" ("+msg+")");
+            };
             if (value === null) { // NULL values for optional fields
                 if (this.required)
                     fail(typeof value, "required");

--- a/src/ProtoBuf/Reflect/Element.js
+++ b/src/ProtoBuf/Reflect/Element.js
@@ -102,9 +102,10 @@ function mkLong(value, unsigned) {
  * @expose
  */
 ElementPrototype.verifyValue = function(value) {
+    var self = this;
     var fail = function(val, msg) {
-        throw Error("Illegal value for "+this.toString(true)+" of type "+this.type.name+": "+val+" ("+msg+")");
-    }.bind(this);
+        throw Error("Illegal value for "+self.toString(true)+" of type "+this.type.name+": "+val+" ("+msg+")");
+    };
     switch (this.type) {
         // Signed 32bit
         case ProtoBuf.TYPES["int32"]:

--- a/src/ProtoBuf/Reflect/Message/Field.js
+++ b/src/ProtoBuf/Reflect/Message/Field.js
@@ -165,9 +165,10 @@ FieldPrototype.build = function() {
  */
 FieldPrototype.verifyValue = function(value, skipRepeated) {
     skipRepeated = skipRepeated || false;
+    var self = this;
     var fail = function(val, msg) {
-        throw Error("Illegal value for "+this.toString(true)+" of type "+this.type.name+": "+val+" ("+msg+")");
-    }.bind(this);
+        throw Error("Illegal value for "+self.toString(true)+" of type "+this.type.name+": "+val+" ("+msg+")");
+    };
     if (value === null) { // NULL values for optional fields
         if (this.required)
             fail(typeof value, "required");


### PR DESCRIPTION
Some evidence that we can improve a bit the performance by not calling bind so many times:

![](https://dl.dropbox.com/s/tngr2wab7k82jre/ss-2015-12-03T10-46-36.png?dl=0)