### PR TITLE
Coalesce to empty string when service response is empty

### DIFF
--- a/src/ProtoBuf/Builder/Service.js
+++ b/src/ProtoBuf/Builder/Service.js
@@ -77,6 +77,9 @@ for (var i=0; i<rpc.length; i++) {
                         callback(err);
                         return;
                     }
+                    // Coalesce to empty string when service response has empty content
+                    if (res === null)
+                        res = ''
                     try { res = method.resolvedResponseType.clazz.decode(res); } catch (notABuffer) {}
                     if (!res || !(res instanceof method.resolvedResponseType.clazz)) {
                         callback(Error("Illegal response type received in service method "+ T.name+"#"+method.name));


### PR DESCRIPTION
For my protobuf services, I'm using plain HTTP POST as RPC implementation.  The protobuf request message is sent as arraybuffer in the request body, and the response message is sent as arraybuffer in the response body.  The response body may be empty if the response message only has default values, especially with proto3.  In this case protobuf.js fails with `Error("Illegal response type received in service method...")`.  Please find enclosed a fix for this usecase.

For reference please have a look to W3C's XMLHttpRequest specification, stating clearly that the response body entity may be `null`: http://www.w3.org/TR/XMLHttpRequest/#response-entity-body