### PR TITLE
Allow to set syntax in JS cli output

### DIFF
--- a/cli/pbjs/targets/json.js
+++ b/cli/pbjs/targets/json.js
@@ -40,6 +40,8 @@ var json = module.exports = function(builder, options) {
         out = {
             "package": pkg !== "" ? pkg : null
         };
+    if (options.syntax)
+        out.syntax = options.syntax
     buildNamespace(ptr, out);
     return JSON.stringify(out, null, options.min ? 0 : 4);
 };


### PR DESCRIPTION
protobuf.js's behaviour regarding default values is driven by the syntax: proto2 or proto3.  The enclosed patch makes it possible to select the syntax with the JS generator cli, by passing an extra attribute in `options`.