### PR TITLE
Performance optimizations

### DIFF
--- a/dist/protobuf-light.js
+++ b/dist/protobuf-light.js
@@ -865,7 +865,6 @@
          * @param {boolean=} unsigned Whether unsigned or not, defaults to reuse it from Long-like objects or to signed for
          *  strings and numbers
          * @returns {!Long}
-         * @throws {Error} If the value cannot be converted to a Long
          * @inner
          */
         function mkLong(value, unsigned) {
@@ -876,8 +875,16 @@
                 return ProtoBuf.Long.fromString(value, unsigned || false, 10);
             if (typeof value === 'number')
                 return ProtoBuf.Long.fromNumber(value, unsigned || false);
-            throw Error("not convertible to Long");
         }
+
+        /**
+         * Fails verification.
+         * @override
+         * @expose
+         */
+        ElementPrototype.failVerify = function(val, msg) {
+            throw Error("Illegal value for "+this.toString(true)+" of type "+this.type.name+": "+val+" ("+msg+")");
+        };
 
         /**
          * Checks if the given value can be set for an element of this type (singular
@@ -888,9 +895,6 @@
          * @expose
          */
         ElementPrototype.verifyValue = function(value) {
-            var fail = function(val, msg) {
-                throw Error("Illegal value for "+this.toString(true)+" of type "+this.type.name+": "+val+" ("+msg+")");
-            }.bind(this);
             switch (this.type) {
                 // Signed 32bit
                 case ProtoBuf.TYPES["int32"]:
@@ -898,14 +902,14 @@
                 case ProtoBuf.TYPES["sfixed32"]:
                     // Account for !NaN: value === value
                     if (typeof value !== 'number' || (value === value && value % 1 !== 0))
-                        fail(typeof value, "not an integer");
+                        this.failVerify(typeof value, "not an integer");
                     return value > 4294967295 ? value | 0 : value;
 
                 // Unsigned 32bit
                 case ProtoBuf.TYPES["uint32"]:
                 case ProtoBuf.TYPES["fixed32"]:
                     if (typeof value !== 'number' || (value === value && value % 1 !== 0))
-                        fail(typeof value, "not an integer");
+                        this.failVerify(typeof value, "not an integer");
                     return value < 0 ? value >>> 0 : value;
 
                 // Signed 64bit
@@ -913,45 +917,37 @@
                 case ProtoBuf.TYPES["sint64"]:
                 case ProtoBuf.TYPES["sfixed64"]: {
                     if (ProtoBuf.Long)
-                        try {
-                            return mkLong(value, false);
-                        } catch (e) {
-                            fail(typeof value, e.message);
-                        }
+                        return mkLong(value, false) || this.failVerify(typeof value, e.message);
                     else
-                        fail(typeof value, "requires Long.js");
+                        this.failVerify(typeof value, "requires Long.js");
                 }
 
                 // Unsigned 64bit
                 case ProtoBuf.TYPES["uint64"]:
                 case ProtoBuf.TYPES["fixed64"]: {
                     if (ProtoBuf.Long)
-                        try {
-                            return mkLong(value, true);
-                        } catch (e) {
-                            fail(typeof value, e.message);
-                        }
+                        return mkLong(value, true) || this.failVerify(typeof value, e.message);
                     else
-                        fail(typeof value, "requires Long.js");
+                        this.failVerify(typeof value, "requires Long.js");
                 }
 
                 // Bool
                 case ProtoBuf.TYPES["bool"]:
                     if (typeof value !== 'boolean')
-                        fail(typeof value, "not a boolean");
+                        this.failVerify(typeof value, "not a boolean");
                     return value;
 
                 // Float
                 case ProtoBuf.TYPES["float"]:
                 case ProtoBuf.TYPES["double"]:
                     if (typeof value !== 'number')
-                        fail(typeof value, "not a number");
+                        this.failVerify(typeof value, "not a number");
                     return value;
 
                 // Length-delimited string
                 case ProtoBuf.TYPES["string"]:
                     if (typeof value !== 'string' && !(value && value instanceof String))
-                        fail(typeof value, "not a string");
+                        this.failVerify(typeof value, "not a string");
                     return ""+value; // Convert String object to string
 
                 // Length-delimited bytes
@@ -972,20 +968,20 @@
                     if (this.syntax === 'proto3') {
                         // proto3: just make sure it's an integer.
                         if (typeof value !== 'number' || (value === value && value % 1 !== 0))
-                            fail(typeof value, "not an integer");
+                            this.failVerify(typeof value, "not an integer");
                         if (value > 4294967295 || value < 0)
-                            fail(typeof value, "not in range for uint32")
+                            this.failVerify(typeof value, "not in range for uint32")
                         return value;
                     } else {
                         // proto2 requires enum values to be valid.
-                        fail(value, "not a valid enum value");
+                        this.failVerify(value, "not a valid enum value");
                     }
                 }
                 // Embedded message
                 case ProtoBuf.TYPES["group"]:
                 case ProtoBuf.TYPES["message"]: {
                     if (!value || typeof value !== 'object')
-                        fail(typeof value, "object expected");
+                        this.failVerify(typeof value, "object expected");
                     if (value instanceof this.resolvedType.clazz)
                         return value;
                     if (value instanceof ProtoBuf.Builder.Message) {
@@ -2512,6 +2508,15 @@
         };
 
         /**
+         * Fails verification.
+         * @override
+         * @expose
+         */
+        FieldPrototype.failVerify = function(val, msg) {
+            throw Error("Illegal value for "+this.toString(true)+" of type "+this.type.name+": "+val+" ("+msg+")");
+        };
+
+        /**
          * Checks if the given value can be set for this field.
          * @param {*} value Value to check
          * @param {boolean=} skipRepeated Whether to skip the repeated value check or not. Defaults to false.
@@ -2520,31 +2525,27 @@
          * @expose
          */
         FieldPrototype.verifyValue = function(value, skipRepeated) {
-            skipRepeated = skipRepeated || false;
-            var fail = function(val, msg) {
-                throw Error("Illegal value for "+this.toString(true)+" of type "+this.type.name+": "+val+" ("+msg+")");
-            }.bind(this);
             if (value === null) { // NULL values for optional fields
                 if (this.required)
-                    fail(typeof value, "required");
+                    this.failVerify(typeof value, "required");
                 if (this.syntax === 'proto3' && this.type !== ProtoBuf.TYPES["message"])
-                    fail(typeof value, "proto3 field without field presence cannot be null");
+                    this.failVerify(typeof value, "proto3 field without field presence cannot be null");
                 return null;
             }
             var i;
             if (this.repeated && !skipRepeated) { // Repeated values as arrays
                 if (!Array.isArray(value))
                     value = [value];
-                var res = [];
+                var res = new Array(value.length);
                 for (i=0; i<value.length; i++)
-                    res.push(this.element.verifyValue(value[i]));
+                    res[i] = this.element.verifyValue(value[i]);
                 return res;
             }
             if (this.map && !skipRepeated) { // Map values as objects
                 if (!(value instanceof ProtoBuf.Map)) {
                     // If not already a Map, attempt to convert.
                     if (!(value instanceof Object)) {
-                        fail(typeof value,
+                        this.failVerify(typeof value,
                              "expected ProtoBuf.Map or raw object for map field");
                     }
                     return new ProtoBuf.Map(this, value);
@@ -2554,7 +2555,7 @@
             }
             // All non-repeated fields expect no array
             if (!this.repeated && Array.isArray(value))
-                fail(typeof value, "no array expected");
+                this.failVerify(typeof value, "no array expected");
 
             return this.element.verifyValue(value);
         };

--- a/dist/protobuf.js
+++ b/dist/protobuf.js
@@ -1771,7 +1771,6 @@
          * @param {boolean=} unsigned Whether unsigned or not, defaults to reuse it from Long-like objects or to signed for
          *  strings and numbers
          * @returns {!Long}
-         * @throws {Error} If the value cannot be converted to a Long
          * @inner
          */
         function mkLong(value, unsigned) {
@@ -1782,8 +1781,16 @@
                 return ProtoBuf.Long.fromString(value, unsigned || false, 10);
             if (typeof value === 'number')
                 return ProtoBuf.Long.fromNumber(value, unsigned || false);
-            throw Error("not convertible to Long");
         }
+
+        /**
+         * Fails verification.
+         * @override
+         * @expose
+         */
+        ElementPrototype.failVerify = function(val, msg) {
+            throw Error("Illegal value for "+this.toString(true)+" of type "+this.type.name+": "+val+" ("+msg+")");
+        };
 
         /**
          * Checks if the given value can be set for an element of this type (singular
@@ -1794,9 +1801,6 @@
          * @expose
          */
         ElementPrototype.verifyValue = function(value) {
-            var fail = function(val, msg) {
-                throw Error("Illegal value for "+this.toString(true)+" of type "+this.type.name+": "+val+" ("+msg+")");
-            }.bind(this);
             switch (this.type) {
                 // Signed 32bit
                 case ProtoBuf.TYPES["int32"]:
@@ -1804,14 +1808,14 @@
                 case ProtoBuf.TYPES["sfixed32"]:
                     // Account for !NaN: value === value
                     if (typeof value !== 'number' || (value === value && value % 1 !== 0))
-                        fail(typeof value, "not an integer");
+                        this.failVerify(typeof value, "not an integer");
                     return value > 4294967295 ? value | 0 : value;
 
                 // Unsigned 32bit
                 case ProtoBuf.TYPES["uint32"]:
                 case ProtoBuf.TYPES["fixed32"]:
                     if (typeof value !== 'number' || (value === value && value % 1 !== 0))
-                        fail(typeof value, "not an integer");
+                        this.failVerify(typeof value, "not an integer");
                     return value < 0 ? value >>> 0 : value;
 
                 // Signed 64bit
@@ -1819,45 +1823,37 @@
                 case ProtoBuf.TYPES["sint64"]:
                 case ProtoBuf.TYPES["sfixed64"]: {
                     if (ProtoBuf.Long)
-                        try {
-                            return mkLong(value, false);
-                        } catch (e) {
-                            fail(typeof value, e.message);
-                        }
+                        return mkLong(value, false) || this.failVerify(typeof value, e.message);
                     else
-                        fail(typeof value, "requires Long.js");
+                        this.failVerify(typeof value, "requires Long.js");
                 }
 
                 // Unsigned 64bit
                 case ProtoBuf.TYPES["uint64"]:
                 case ProtoBuf.TYPES["fixed64"]: {
                     if (ProtoBuf.Long)
-                        try {
-                            return mkLong(value, true);
-                        } catch (e) {
-                            fail(typeof value, e.message);
-                        }
+                        return mkLong(value, true) || this.failVerify(typeof value, e.message);
                     else
-                        fail(typeof value, "requires Long.js");
+                        this.failVerify(typeof value, "requires Long.js");
                 }
 
                 // Bool
                 case ProtoBuf.TYPES["bool"]:
                     if (typeof value !== 'boolean')
-                        fail(typeof value, "not a boolean");
+                        this.failVerify(typeof value, "not a boolean");
                     return value;
 
                 // Float
                 case ProtoBuf.TYPES["float"]:
                 case ProtoBuf.TYPES["double"]:
                     if (typeof value !== 'number')
-                        fail(typeof value, "not a number");
+                        this.failVerify(typeof value, "not a number");
                     return value;
 
                 // Length-delimited string
                 case ProtoBuf.TYPES["string"]:
                     if (typeof value !== 'string' && !(value && value instanceof String))
-                        fail(typeof value, "not a string");
+                        this.failVerify(typeof value, "not a string");
                     return ""+value; // Convert String object to string
 
                 // Length-delimited bytes
@@ -1878,20 +1874,20 @@
                     if (this.syntax === 'proto3') {
                         // proto3: just make sure it's an integer.
                         if (typeof value !== 'number' || (value === value && value % 1 !== 0))
-                            fail(typeof value, "not an integer");
+                            this.failVerify(typeof value, "not an integer");
                         if (value > 4294967295 || value < 0)
-                            fail(typeof value, "not in range for uint32")
+                            this.failVerify(typeof value, "not in range for uint32")
                         return value;
                     } else {
                         // proto2 requires enum values to be valid.
-                        fail(value, "not a valid enum value");
+                        this.failVerify(value, "not a valid enum value");
                     }
                 }
                 // Embedded message
                 case ProtoBuf.TYPES["group"]:
                 case ProtoBuf.TYPES["message"]: {
                     if (!value || typeof value !== 'object')
-                        fail(typeof value, "object expected");
+                        this.failVerify(typeof value, "object expected");
                     if (value instanceof this.resolvedType.clazz)
                         return value;
                     if (value instanceof ProtoBuf.Builder.Message) {
@@ -3418,6 +3414,15 @@
         };
 
         /**
+         * Fails verification.
+         * @override
+         * @expose
+         */
+        FieldPrototype.failVerify = function(val, msg) {
+            throw Error("Illegal value for "+this.toString(true)+" of type "+this.type.name+": "+val+" ("+msg+")");
+        };
+
+        /**
          * Checks if the given value can be set for this field.
          * @param {*} value Value to check
          * @param {boolean=} skipRepeated Whether to skip the repeated value check or not. Defaults to false.
@@ -3426,31 +3431,27 @@
          * @expose
          */
         FieldPrototype.verifyValue = function(value, skipRepeated) {
-            skipRepeated = skipRepeated || false;
-            var fail = function(val, msg) {
-                throw Error("Illegal value for "+this.toString(true)+" of type "+this.type.name+": "+val+" ("+msg+")");
-            }.bind(this);
             if (value === null) { // NULL values for optional fields
                 if (this.required)
-                    fail(typeof value, "required");
+                    this.failVerify(typeof value, "required");
                 if (this.syntax === 'proto3' && this.type !== ProtoBuf.TYPES["message"])
-                    fail(typeof value, "proto3 field without field presence cannot be null");
+                    this.failVerify(typeof value, "proto3 field without field presence cannot be null");
                 return null;
             }
             var i;
             if (this.repeated && !skipRepeated) { // Repeated values as arrays
                 if (!Array.isArray(value))
                     value = [value];
-                var res = [];
+                var res = new Array(value.length);
                 for (i=0; i<value.length; i++)
-                    res.push(this.element.verifyValue(value[i]));
+                    res[i] = this.element.verifyValue(value[i]);
                 return res;
             }
             if (this.map && !skipRepeated) { // Map values as objects
                 if (!(value instanceof ProtoBuf.Map)) {
                     // If not already a Map, attempt to convert.
                     if (!(value instanceof Object)) {
-                        fail(typeof value,
+                        this.failVerify(typeof value,
                              "expected ProtoBuf.Map or raw object for map field");
                     }
                     return new ProtoBuf.Map(this, value);
@@ -3460,7 +3461,7 @@
             }
             // All non-repeated fields expect no array
             if (!this.repeated && Array.isArray(value))
-                fail(typeof value, "no array expected");
+                this.failVerify(typeof value, "no array expected");
 
             return this.element.verifyValue(value);
         };


### PR DESCRIPTION
By far the largest optimization is removing the function / bind for `fail`. Benchmark results:

```
Old Protobuf.js: count:  978, mean: 60.215909270156000 µs
New Protobuf.js: count: 3364, mean: 15.561118733463415 µs
```