### PR TITLE
Move default values to prototypes and ditch nulls

### DIFF
--- a/src/ProtoBuf/Builder/Message.js
+++ b/src/ProtoBuf/Builder/Message.js
@@ -23,10 +23,11 @@ var Message = function(values, var_args) {
     // Create fields and set default values
     for (i=0, k=fields.length; i<k; ++i) {
         var field = fields[i];
-        this[field.name] =
-            field.repeated ? [] :
-            (field.map ? new ProtoBuf.Map(field) : null);
-        if ((field.required || T.syntax === 'proto3') &&
+        if (field.repeated)
+            this[field.name] = [];
+        else if (field.map)
+            this[field.name] = new ProtoBuf.Map(field);
+        else if (T.syntax === 'proto3' &&
             field.defaultValue !== null)
             this[field.name] = field.defaultValue;
     }
@@ -128,7 +129,7 @@ MessagePrototype.set = function(keyOrObj, value, noAssert) {
         var currentField = this[field.oneof.name]; // Virtual field references currently set field
         if (value !== null) {
             if (currentField !== null && currentField !== field.name)
-                this[currentField] = null; // Clear currently set field
+                delete this[currentField]; // Clear currently set field
             this[field.oneof.name] = field.name; // Point virtual field at this field
         } else if (/* value === null && */currentField === keyOrObj)
             this[field.oneof.name] = null; // Clear virtual field (current field explicitly cleared)

--- a/src/ProtoBuf/Reflect/Message/Field.js
+++ b/src/ProtoBuf/Reflect/Message/Field.js
@@ -145,14 +145,10 @@ FieldPrototype.build = function() {
     if (this.map)
         this.keyElement = new Element(this.keyType, undefined, true, this.syntax);
 
-    // In proto3, fields do not have field presence, and every field is set to
-    // its type's default value ("", 0, 0.0, or false).
-    if (this.syntax === 'proto3' && !this.repeated && !this.map)
-        this.defaultValue = Element.defaultFieldValue(this.type);
-
-    // Otherwise, default values are present when explicitly specified
-    else if (typeof this.options['default'] !== 'undefined')
+    if (typeof this.options['default'] !== 'undefined')
         this.defaultValue = this.verifyValue(this.options['default']);
+    else if (!this.repeated && !this.map)
+        this.defaultValue = Element.defaultFieldValue(this.type);
 };
 
 /**

--- a/src/protobuf.js
+++ b/src/protobuf.js
@@ -248,14 +248,6 @@ ProtoBuf.convertFieldsToCamelCase = false;
  */
 ProtoBuf.populateAccessors = true;
 
-/**
- * By default, messages are populated with default values if a field is not present on the wire. To disable
- *  this behavior, set this setting to `false`.
- * @type {boolean}
- * @expose
- */
-ProtoBuf.populateDefaults = true;
-
 //? include("ProtoBuf/Util.js");
 
 //? include("ProtoBuf/Lang.js");

--- a/tests/suite.js
+++ b/tests/suite.js
@@ -432,7 +432,7 @@
                 var builder = ProtoBuf.loadProto("message Test { optional bool ok = 1 [ default = false ]; }"),
                     Test = builder.build("Test"),
                     t =  new Test();
-                test.strictEqual(t.ok, null); // Not set as it is optional
+                test.strictEqual(t.ok, false); // = default when missing
                 t.setOk(true);
                 test.strictEqual(t.ok, true);
                 test.strictEqual(Test.decode(t.encode()).ok, true);
@@ -561,6 +561,7 @@
                 var Test = builder.build("Test");
                 var t = new Test(), bb = new ByteBuffer(2);
                 t.setA(1);
+                t.b = null;
                 try {
                     bb = t.encode(bb).flip();
                     test.ok(false);
@@ -577,7 +578,7 @@
                     // But still be able to access the rest
                     var t3 = e.decoded;
                     test.strictEqual(t3.a, 1);
-                    test.strictEqual(t3.b, null);
+                    test.strictEqual(t3.b, 0);
                 }
                 test.strictEqual(t2, undefined);
             } catch (e) {
@@ -931,8 +932,8 @@
             ProtoBuf.loadProto(y, builder);
             var Test = builder.build('x.Test');
             var inst = new Test();
-            test.strictEqual(inst[".x.first_val"], null);
-            test.strictEqual(inst[".y.second_val"], null);
+            test.strictEqual(inst[".x.first_val"], 0);
+            test.strictEqual(inst[".y.second_val"], 0);
             test.done();
         },
 
@@ -1148,13 +1149,13 @@
                 test.strictEqual(myOneOf.my_oneof, "id");
                 myOneOf.set("name", "me");
                 test.strictEqual(myOneOf.my_oneof, "name");
-                test.strictEqual(myOneOf.id, null);
+                test.strictEqual(myOneOf.id, 0);
                 var bb = myOneOf.encode().compact();
                 test.strictEqual(bb.toString("debug"), "<12 02 6D 65>"); // id 2, wt 2, len 2
                 myOneOf = MyOneOf.decode(bb);
                 test.strictEqual(myOneOf.my_oneof, "name");
                 test.strictEqual(myOneOf.name, "me");
-                test.strictEqual(myOneOf.id, null);
+                test.strictEqual(myOneOf.id, 0);
             } catch (e) {
                 fail(e);
             }
@@ -1299,12 +1300,12 @@
                 var builder = ProtoBuf.loadProtoFile(__dirname+"/optional.proto");
                 var Test1 = builder.build("Test1");
                 var test1 = new Test1();
-                test.strictEqual(test1.a, null);
-                test.deepEqual(Object.keys(test1), ['a','b']);
+                test.strictEqual(test1.a, 0);
+                test.deepEqual(Object.keys(test1), []);
                 var bb = test1.encode();
                 test1 = Test1.decode(bb);
-                test.strictEqual(test1.a, null);
-                test.deepEqual(Object.keys(test1), ['a','b']);
+                test.strictEqual(test1.a, 0);
+                test.deepEqual(Object.keys(test1), []);
             } catch (e) {
                 fail(e);
             }
@@ -1320,20 +1321,20 @@
                 var msg = new Test();
 
                 // Reverted collision on 1st
-                test.strictEqual(msg.some_field, null);
-                test.strictEqual(msg.someField, null);
+                test.strictEqual(msg.some_field, 0);
+                test.strictEqual(msg.someField, 0);
                 test.equal(TTest.getChild("some_field").id, 1);
                 test.equal(TTest.getChild("someField").id, 2);
 
 
                 // Reverted collision on 2nd
-                test.strictEqual(msg.aField, null);
-                test.strictEqual(msg.a_field, null);
+                test.strictEqual(msg.aField, 0);
+                test.strictEqual(msg.a_field, 0);
                 test.equal(TTest.getChild("aField").id, 3);
                 test.equal(TTest.getChild("a_field").id, 4);
 
                 // No collision
-                test.strictEqual(msg.itsAField, null);
+                test.strictEqual(msg.itsAField, 0);
                 test.equal(TTest.getChild("itsAField").id, 5);
 
                 test.ok(typeof msg.set_its_a_field === "function");


### PR DESCRIPTION
This fixes https://github.com/dcodeIO/protobuf.js/issues/200 by implementing the API described in https://github.com/dcodeIO/protobuf.js/issues/200#issuecomment-98153230.
- Fields without an explicit default are treated as if the default were a type-specific value, as per the spec and the official implementations. For example, `optional bool foo = 0;` is now equivalent to `optional bool foo = 0 [default = false];`.
- For every non-repeated non-map field, there is an equivalently named property on the message prototype. Its value is the field's default value.
- When constructing a message object, its properties are no longer set for non-repeated non-map values. Consequently, attempting to read any of its fields results in the default value.
- When encoding, only own properties are taken into account, unless it's a required field (previously, required fields with explicit defaults were set on construction, so one could encode without explicitly setting them).
- When decoding, fields are no longer set to their defaults if they were missing on the wire, since the default values are already in the prototype. If a required field is missing on the wire, decoding throws even if the field has an explicit default.
- The `ProtoBuf.populateDefaults` option is removed.

The changes are breaking for some (unlikely) use cases, but I tried to be as conservative as possible. Also note that all the above only applies to `proto2`. The behavior of `proto3` should be exactly the same as before.

Also fixes #319, #373.
