### PR TITLE
Exclude tests dir from being published

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
 .idea
 node_modules/
 npm-debug.log
+tests


### PR DESCRIPTION
The gtfs-realtime.proto uses Creative Common licensed code which is not
compatible with Apache licensed code. This fix prevents the publishing
of the tests dir (and it's licensed files), which allows third party
vendors to use the published project.