### PR TITLE
extend support for multiple extension ranges

### DIFF
--- a/src/ProtoBuf/DotProto/Parser.js
+++ b/src/ProtoBuf/DotProto/Parser.js
@@ -428,7 +428,11 @@ ParserPrototype._parseMessage = function(parent, fld) {
         else if (token === "service")
             this._parseService(msg);
         else if (token === "extensions")
-            msg["extensions"] = this._parseExtensionRanges();
+            if (msg.hasOwnProperty("extensions")) {
+                msg["extensions"] = msg["extensions"].concat(this._parseExtensionRanges())
+            } else {
+                msg["extensions"] = this._parseExtensionRanges();
+            }
         else if (token === "reserved")
             this._parseIgnored(); // TODO
         else if (token === "extend")


### PR DESCRIPTION
This fixes a bug for multiple extension ranges if they are defined in the following way:

```protobuf
message Request
{
    extensions 50 to 90;
    extensions 200 to 300; 
}
```

The old implementation only uses the last extension range.