### PR TITLE
Fix using constructor to copy a message containging oneofs

### DIFF
--- a/dist/protobuf-light.js
+++ b/dist/protobuf-light.js
@@ -1553,9 +1553,11 @@
                 MessagePrototype.set = function(keyOrObj, value, noAssert) {
                     if (keyOrObj && typeof keyOrObj === 'object') {
                         noAssert = value;
-                        for (var ikey in keyOrObj)
-                            if (keyOrObj.hasOwnProperty(ikey) && typeof (value = keyOrObj[ikey]) !== 'undefined')
+                        for (var ikey in keyOrObj) {
+                            // Check if virtual oneof field - don't set these
+                            if (keyOrObj.hasOwnProperty(ikey) && typeof (value = keyOrObj[ikey]) !== 'undefined' && T._oneofsByName[ikey] === undefined)
                                 this.$set(ikey, value, noAssert);
+                        }
                         return this;
                     }
                     var field = T._fieldsByName[keyOrObj];
@@ -2167,6 +2169,7 @@
             this._fields = [];
             this._fieldsById = {};
             this._fieldsByName = {};
+            this._oneofsByName = {};
             for (var i=0, k=this.children.length, child; i<k; i++) {
                 child = this.children[i];
                 if (child instanceof Enum || child instanceof Message || child instanceof Service) {
@@ -2178,6 +2181,9 @@
                     this._fields.push(child),
                     this._fieldsById[child.id] = child,
                     this._fieldsByName[child.name] = child;
+                else if (child instanceof Message.OneOf) {
+                    this._oneofsByName[child.name] = child;
+                }
                 else if (!(child instanceof Message.OneOf) && !(child instanceof Extension)) // Not built
                     throw Error("Illegal reflect child of "+this.toString(true)+": "+this.children[i].toString(true));
             }

--- a/dist/protobuf.js
+++ b/dist/protobuf.js
@@ -1103,7 +1103,11 @@
                 else if (token === "service")
                     this._parseService(msg);
                 else if (token === "extensions")
-                    msg["extensions"] = this._parseExtensionRanges();
+                    if (msg.hasOwnProperty("extensions")) {
+                        msg["extensions"] = msg["extensions"].concat(this._parseExtensionRanges())
+                    } else {
+                        msg["extensions"] = this._parseExtensionRanges();
+                    }
                 else if (token === "reserved")
                     this._parseIgnored(); // TODO
                 else if (token === "extend")
@@ -2461,9 +2465,11 @@
                 MessagePrototype.set = function(keyOrObj, value, noAssert) {
                     if (keyOrObj && typeof keyOrObj === 'object') {
                         noAssert = value;
-                        for (var ikey in keyOrObj)
-                            if (keyOrObj.hasOwnProperty(ikey) && typeof (value = keyOrObj[ikey]) !== 'undefined')
+                        for (var ikey in keyOrObj) {
+                            // Check if virtual oneof field - don't set these
+                            if (keyOrObj.hasOwnProperty(ikey) && typeof (value = keyOrObj[ikey]) !== 'undefined' && T._oneofsByName[ikey] === undefined)
                                 this.$set(ikey, value, noAssert);
+                        }
                         return this;
                     }
                     var field = T._fieldsByName[keyOrObj];
@@ -3075,6 +3081,7 @@
             this._fields = [];
             this._fieldsById = {};
             this._fieldsByName = {};
+            this._oneofsByName = {};
             for (var i=0, k=this.children.length, child; i<k; i++) {
                 child = this.children[i];
                 if (child instanceof Enum || child instanceof Message || child instanceof Service) {
@@ -3086,6 +3093,9 @@
                     this._fields.push(child),
                     this._fieldsById[child.id] = child,
                     this._fieldsByName[child.name] = child;
+                else if (child instanceof Message.OneOf) {
+                    this._oneofsByName[child.name] = child;
+                }
                 else if (!(child instanceof Message.OneOf) && !(child instanceof Extension)) // Not built
                     throw Error("Illegal reflect child of "+this.toString(true)+": "+this.children[i].toString(true));
             }

--- a/src/ProtoBuf/Builder/Message.js
+++ b/src/ProtoBuf/Builder/Message.js
@@ -110,9 +110,11 @@ MessagePrototype.$add = MessagePrototype.add;
 MessagePrototype.set = function(keyOrObj, value, noAssert) {
     if (keyOrObj && typeof keyOrObj === 'object') {
         noAssert = value;
-        for (var ikey in keyOrObj)
-            if (keyOrObj.hasOwnProperty(ikey) && typeof (value = keyOrObj[ikey]) !== 'undefined')
+        for (var ikey in keyOrObj) {
+            // Check if virtual oneof field - don't set these
+            if (keyOrObj.hasOwnProperty(ikey) && typeof (value = keyOrObj[ikey]) !== 'undefined' && T._oneofsByName[ikey] === undefined)
                 this.$set(ikey, value, noAssert);
+        }
         return this;
     }
     var field = T._fieldsByName[keyOrObj];

--- a/src/ProtoBuf/Reflect/Message.js
+++ b/src/ProtoBuf/Reflect/Message.js
@@ -94,6 +94,7 @@ MessagePrototype.build = function(rebuild) {
     this._fields = [];
     this._fieldsById = {};
     this._fieldsByName = {};
+    this._oneofsByName = {};
     for (var i=0, k=this.children.length, child; i<k; i++) {
         child = this.children[i];
         if (child instanceof Enum || child instanceof Message || child instanceof Service) {
@@ -105,6 +106,9 @@ MessagePrototype.build = function(rebuild) {
             this._fields.push(child),
             this._fieldsById[child.id] = child,
             this._fieldsByName[child.name] = child;
+        else if (child instanceof Message.OneOf) {
+            this._oneofsByName[child.name] = child;
+        }
         else if (!(child instanceof Message.OneOf) && !(child instanceof Extension)) // Not built
             throw Error("Illegal reflect child of "+this.toString(true)+": "+this.children[i].toString(true));
     }

--- a/tests/suite.js
+++ b/tests/suite.js
@@ -263,6 +263,36 @@
             test.deepEqual(t2, t3);
             test.done();
         },
+        
+        "constructorWithOneofs": function(test) {
+            try {
+                var builder = ProtoBuf.loadProtoFile(__dirname+"/oneof.proto"),
+                    MyOneOf = builder.build("MyOneOf"),
+                    TOneOf = builder.lookup(".MyOneOf");
+                test.ok(TOneOf.getChild("my_oneof"));
+                
+                var myOneOf = new MyOneOf();
+                test.strictEqual(myOneOf.my_oneof, null);
+                myOneOf.set("id", 1);
+                test.strictEqual(myOneOf.my_oneof, "id");
+                myOneOf.set("name", "me");
+                test.strictEqual(myOneOf.my_oneof, "name");
+                test.strictEqual(myOneOf.id, null);
+                
+                var copy = new MyOneOf(myOneOf); // this line is what was failing
+                // Error: .MyOneOf#my_oneof is not a field: undefined
+                
+                test.deepEqual(myOneOf, copy);
+                
+                // Test same things are there
+                test.strictEqual(copy.my_oneof, "name");
+                test.strictEqual(copy.name, "me");
+                test.strictEqual(copy.id, null);
+            } catch (e) {
+                fail(e);
+            }
+            test.done();
+        },
 
         "numberFormats": function(test) {
             try {


### PR DESCRIPTION
See test case I added for example of what was failing.
It throws an error complaining the the virtual oneof field doesn't exist.

Fixed by not trying to set a virtual oneof field in the first place, when setting a property from an object.
Required creating a _oneofsByName map for efficient lookup.