### PR TITLE
Constructors and set/add should perform a deep copy

### DIFF
--- a/dist/protobuf-light.js
+++ b/dist/protobuf-light.js
@@ -1553,9 +1553,11 @@
                 MessagePrototype.set = function(keyOrObj, value, noAssert) {
                     if (keyOrObj && typeof keyOrObj === 'object') {
                         noAssert = value;
-                        for (var ikey in keyOrObj)
-                            if (keyOrObj.hasOwnProperty(ikey) && typeof (value = keyOrObj[ikey]) !== 'undefined')
+                        for (var ikey in keyOrObj) {
+                            // Check if virtual oneof field - don't set these
+                            if (keyOrObj.hasOwnProperty(ikey) && typeof (value = keyOrObj[ikey]) !== 'undefined' && T._oneofsByName[ikey] === undefined)
                                 this.$set(ikey, value, noAssert);
+                        }
                         return this;
                     }
                     var field = T._fieldsByName[keyOrObj];
@@ -2167,6 +2169,7 @@
             this._fields = [];
             this._fieldsById = {};
             this._fieldsByName = {};
+            this._oneofsByName = {};
             for (var i=0, k=this.children.length, child; i<k; i++) {
                 child = this.children[i];
                 if (child instanceof Enum || child instanceof Message || child instanceof Service) {
@@ -2178,6 +2181,9 @@
                     this._fields.push(child),
                     this._fieldsById[child.id] = child,
                     this._fieldsByName[child.name] = child;
+                else if (child instanceof Message.OneOf) {
+                    this._oneofsByName[child.name] = child;
+                }
                 else if (!(child instanceof Message.OneOf) && !(child instanceof Extension)) // Not built
                     throw Error("Illegal reflect child of "+this.toString(true)+": "+this.children[i].toString(true));
             }

--- a/dist/protobuf.js
+++ b/dist/protobuf.js
@@ -1795,11 +1795,14 @@
          * Checks if the given value can be set for an element of this type (singular
          * field or one element of a repeated field or map).
          * @param {*} value Value to check
+         * @param {*} deepCopy Whether to make a deep copy of the value. Defaults to false.
          * @return {*} Verified, maybe adjusted, value
          * @throws {Error} If the value cannot be verified for this element slot
          * @expose
          */
-        ElementPrototype.verifyValue = function(value) {
+        ElementPrototype.verifyValue = function(value, deepCopy) {
+            deepCopy = deepCopy || false;
+
             var self = this;
             function fail(val, msg) {
                 throw Error("Illegal value for "+self.toString(true)+" of type "+self.type.name+": "+val+" ("+msg+")");
@@ -1869,8 +1872,12 @@
 
                 // Length-delimited bytes
                 case ProtoBuf.TYPES["bytes"]:
-                    if (ByteBuffer.isByteBuffer(value))
-                        return value;
+                    if (ByteBuffer.isByteBuffer(value)) {
+                        if(deepCopy)
+                            return value;
+                        else
+                            return value.copy();
+                    }
                     return ByteBuffer.wrap(value, "base64");
 
                 // Constant enum value
@@ -1899,8 +1906,12 @@
                 case ProtoBuf.TYPES["message"]: {
                     if (!value || typeof value !== 'object')
                         fail(typeof value, "object expected");
-                    if (value instanceof this.resolvedType.clazz)
-                        return value;
+                    if (value instanceof this.resolvedType.clazz) {
+                        if(deepCopy)
+                            return new (this.resolvedType.clazz)(value);
+                        else
+                            return value;
+                    }
                     if (value instanceof ProtoBuf.Builder.Message) {
                         // Mismatched type: Convert to object (see: https://github.com/dcodeIO/ProtoBuf.js/issues/180)
                         var obj = {};
@@ -2416,7 +2427,7 @@
                  * @function
                  * @param {string} key Field name
                  * @param {*} value Value to add
-                 * @param {boolean=} noAssert Whether to assert the value or not (asserts by default)
+                 * @param {boolean=} noAssert Whether to assert the value or not (asserts by default). If false (default), a deep copy will be made.
                  * @returns {!ProtoBuf.Builder.Message} this
                  * @throws {Error} If the value cannot be added
                  * @expose
@@ -2430,7 +2441,7 @@
                             throw Error(this+"#"+key+" is not a field: "+field.toString(true)); // May throw if it's an enum or embedded message
                         if (!field.repeated)
                             throw Error(this+"#"+key+" is not a repeated field");
-                        value = field.verifyValue(value, true);
+                        value = field.copyValue(value, true);
                     }
                     if (this[key] === null)
                         this[key] = [];
@@ -2457,7 +2468,7 @@
                  * @function
                  * @param {string|!Object.<string,*>} keyOrObj String key or plain object holding multiple values
                  * @param {(*|boolean)=} value Value to set if key is a string, otherwise omitted
-                 * @param {boolean=} noAssert Whether to not assert for an actual field / proper value type, defaults to `false`
+                 * @param {boolean=} noAssert Whether to not assert for an actual field / proper value type, defaults to `false`. If false, a deep copy will be made.
                  * @returns {!ProtoBuf.Builder.Message} this
                  * @throws {Error} If the value cannot be set
                  * @expose
@@ -2478,7 +2489,7 @@
                             throw Error(this+"#"+keyOrObj+" is not a field: undefined");
                         if (!(field instanceof ProtoBuf.Reflect.Message.Field))
                             throw Error(this+"#"+keyOrObj+" is not a field: "+field.toString(true));
-                        this[field.name] = (value = field.verifyValue(value)); // May throw
+                        this[field.name] = (value = field.copyValue(value)); // May throw
                     } else
                         this[keyOrObj] = value;
                     if (field && field.oneof) { // Field is part of an OneOf (not a virtual OneOf field)
@@ -3439,12 +3450,15 @@
          * Checks if the given value can be set for this field.
          * @param {*} value Value to check
          * @param {boolean=} skipRepeated Whether to skip the repeated value check or not. Defaults to false.
+         * @param {*} deepCopy Whether to make a deep copy of the value. Defaults to false.
          * @return {*} Verified, maybe adjusted, value
          * @throws {Error} If the value cannot be set for this field
          * @expose
          */
-        FieldPrototype.verifyValue = function(value, skipRepeated) {
+        FieldPrototype.verifyValue = function(value, skipRepeated, deepCopy) {
             skipRepeated = skipRepeated || false;
+            deepCopy = deepCopy || false;
+
             var self = this;
             function fail(val, msg) {
                 throw Error("Illegal value for "+self.toString(true)+" of type "+self.type.name+": "+val+" ("+msg+")");
@@ -3462,7 +3476,7 @@
                     value = [value];
                 var res = [];
                 for (i=0; i<value.length; i++)
-                    res.push(this.element.verifyValue(value[i]));
+                    res.push(this.element.verifyValue(value[i], deepCopy));
                 return res;
             }
             if (this.map && !skipRepeated) { // Map values as objects
@@ -3474,15 +3488,41 @@
                     }
                     return new ProtoBuf.Map(this, value);
                 } else {
-                    return value;
+                    if(deepCopy)
+                    {
+                        var map = new ProtoBuf.Map(this, {});
+
+                        for(var i in value.map) {
+                            var item = value.map[i];
+                            map.set(item.key, this.verifyValue(item.value, true, true));
+                        }
+
+                        return map;
+                    }
+                    else
+                        return value;
                 }
             }
             // All non-repeated fields expect no array
             if (!this.repeated && Array.isArray(value))
                 fail(typeof value, "no array expected");
 
-            return this.element.verifyValue(value);
+            return this.element.verifyValue(value, deepCopy);
         };
+
+        /**
+         * Checks if the given value can be set for this field, and makes a deep copy.
+         * @param {*} value Value to check & copy
+         *  * @param {boolean=} skipRepeated Whether to skip the repeated value check or not. Defaults to false. Useful for copying values that belong in an array.
+         * @return {*} Verified, maybe adjusted, deep copy of value
+         * @throws {Error} If the value cannot be set for this field
+         * @expose
+         */
+        FieldPrototype.copyValue = function(value, skipRepeated) {
+            skipRepeated = skipRepeated || false;
+            value = this.verifyValue(value, skipRepeated, true);
+            return value;
+        }
 
         /**
          * Determines whether the field will have a presence on the wire given its
@@ -4949,7 +4989,7 @@
                 var keys = Object.keys(contents);
                 for (var i = 0; i < keys.length; i++) {
                     var key = this.keyElem.valueFromString(keys[i]);
-                    var val = this.valueElem.verifyValue(contents[keys[i]]);
+                    var val = this.valueElem.verifyValue(contents[keys[i]], true);
                     this.map[this.keyElem.valueToString(key)] =
                         { key: key, value: val };
                 }
@@ -5047,8 +5087,8 @@
          * @returns {!ProtoBuf.Map} The map instance
          */
         MapPrototype.set = function(key, value) {
-            var keyValue = this.keyElem.verifyValue(key);
-            var valValue = this.valueElem.verifyValue(value);
+            var keyValue = this.keyElem.verifyValue(key, true);
+            var valValue = this.valueElem.verifyValue(value, true);
             this.map[this.keyElem.valueToString(keyValue)] =
                 { key: keyValue, value: valValue };
             return this;

--- a/dist/protobuf.js
+++ b/dist/protobuf.js
@@ -1103,7 +1103,11 @@
                 else if (token === "service")
                     this._parseService(msg);
                 else if (token === "extensions")
-                    msg["extensions"] = this._parseExtensionRanges();
+                    if (msg.hasOwnProperty("extensions")) {
+                        msg["extensions"] = msg["extensions"].concat(this._parseExtensionRanges())
+                    } else {
+                        msg["extensions"] = this._parseExtensionRanges();
+                    }
                 else if (token === "reserved")
                     this._parseIgnored(); // TODO
                 else if (token === "extend")
@@ -2461,9 +2465,11 @@
                 MessagePrototype.set = function(keyOrObj, value, noAssert) {
                     if (keyOrObj && typeof keyOrObj === 'object') {
                         noAssert = value;
-                        for (var ikey in keyOrObj)
-                            if (keyOrObj.hasOwnProperty(ikey) && typeof (value = keyOrObj[ikey]) !== 'undefined')
+                        for (var ikey in keyOrObj) {
+                            // Check if virtual oneof field - don't set these
+                            if (keyOrObj.hasOwnProperty(ikey) && typeof (value = keyOrObj[ikey]) !== 'undefined' && T._oneofsByName[ikey] === undefined)
                                 this.$set(ikey, value, noAssert);
+                        }
                         return this;
                     }
                     var field = T._fieldsByName[keyOrObj];
@@ -3075,6 +3081,7 @@
             this._fields = [];
             this._fieldsById = {};
             this._fieldsByName = {};
+            this._oneofsByName = {};
             for (var i=0, k=this.children.length, child; i<k; i++) {
                 child = this.children[i];
                 if (child instanceof Enum || child instanceof Message || child instanceof Service) {
@@ -3086,6 +3093,9 @@
                     this._fields.push(child),
                     this._fieldsById[child.id] = child,
                     this._fieldsByName[child.name] = child;
+                else if (child instanceof Message.OneOf) {
+                    this._oneofsByName[child.name] = child;
+                }
                 else if (!(child instanceof Message.OneOf) && !(child instanceof Extension)) // Not built
                     throw Error("Illegal reflect child of "+this.toString(true)+": "+this.children[i].toString(true));
             }

--- a/src/ProtoBuf/Builder/Message.js
+++ b/src/ProtoBuf/Builder/Message.js
@@ -110,9 +110,11 @@ MessagePrototype.$add = MessagePrototype.add;
 MessagePrototype.set = function(keyOrObj, value, noAssert) {
     if (keyOrObj && typeof keyOrObj === 'object') {
         noAssert = value;
-        for (var ikey in keyOrObj)
-            if (keyOrObj.hasOwnProperty(ikey) && typeof (value = keyOrObj[ikey]) !== 'undefined')
+        for (var ikey in keyOrObj) {
+            // Check if virtual oneof field - don't set these
+            if (keyOrObj.hasOwnProperty(ikey) && typeof (value = keyOrObj[ikey]) !== 'undefined' && T._oneofsByName[ikey] === undefined)
                 this.$set(ikey, value, noAssert);
+        }
         return this;
     }
     var field = T._fieldsByName[keyOrObj];

--- a/src/ProtoBuf/Builder/Message.js
+++ b/src/ProtoBuf/Builder/Message.js
@@ -61,7 +61,7 @@ var MessagePrototype = Message.prototype = Object.create(ProtoBuf.Builder.Messag
  * @function
  * @param {string} key Field name
  * @param {*} value Value to add
- * @param {boolean=} noAssert Whether to assert the value or not (asserts by default)
+ * @param {boolean=} noAssert Whether to assert the value or not (asserts by default). If false (default), a deep copy will be made.
  * @returns {!ProtoBuf.Builder.Message} this
  * @throws {Error} If the value cannot be added
  * @expose
@@ -75,7 +75,7 @@ MessagePrototype.add = function(key, value, noAssert) {
             throw Error(this+"#"+key+" is not a field: "+field.toString(true)); // May throw if it's an enum or embedded message
         if (!field.repeated)
             throw Error(this+"#"+key+" is not a repeated field");
-        value = field.verifyValue(value, true);
+        value = field.copyValue(value, true);
     }
     if (this[key] === null)
         this[key] = [];
@@ -102,7 +102,7 @@ MessagePrototype.$add = MessagePrototype.add;
  * @function
  * @param {string|!Object.<string,*>} keyOrObj String key or plain object holding multiple values
  * @param {(*|boolean)=} value Value to set if key is a string, otherwise omitted
- * @param {boolean=} noAssert Whether to not assert for an actual field / proper value type, defaults to `false`
+ * @param {boolean=} noAssert Whether to not assert for an actual field / proper value type, defaults to `false`. If false, a deep copy will be made.
  * @returns {!ProtoBuf.Builder.Message} this
  * @throws {Error} If the value cannot be set
  * @expose
@@ -123,7 +123,7 @@ MessagePrototype.set = function(keyOrObj, value, noAssert) {
             throw Error(this+"#"+keyOrObj+" is not a field: undefined");
         if (!(field instanceof ProtoBuf.Reflect.Message.Field))
             throw Error(this+"#"+keyOrObj+" is not a field: "+field.toString(true));
-        this[field.name] = (value = field.verifyValue(value)); // May throw
+        this[field.name] = (value = field.copyValue(value)); // May throw
     } else
         this[keyOrObj] = value;
     if (field && field.oneof) { // Field is part of an OneOf (not a virtual OneOf field)

--- a/src/ProtoBuf/Map.js
+++ b/src/ProtoBuf/Map.js
@@ -66,7 +66,7 @@ ProtoBuf.Map = (function(ProtoBuf, Reflect) {
             var keys = Object.keys(contents);
             for (var i = 0; i < keys.length; i++) {
                 var key = this.keyElem.valueFromString(keys[i]);
-                var val = this.valueElem.verifyValue(contents[keys[i]]);
+                var val = this.valueElem.verifyValue(contents[keys[i]], true);
                 this.map[this.keyElem.valueToString(key)] =
                     { key: key, value: val };
             }
@@ -164,8 +164,8 @@ ProtoBuf.Map = (function(ProtoBuf, Reflect) {
      * @returns {!ProtoBuf.Map} The map instance
      */
     MapPrototype.set = function(key, value) {
-        var keyValue = this.keyElem.verifyValue(key);
-        var valValue = this.valueElem.verifyValue(value);
+        var keyValue = this.keyElem.verifyValue(key, true);
+        var valValue = this.valueElem.verifyValue(value, true);
         this.map[this.keyElem.valueToString(keyValue)] =
             { key: keyValue, value: valValue };
         return this;

--- a/src/ProtoBuf/Reflect/Message.js
+++ b/src/ProtoBuf/Reflect/Message.js
@@ -94,6 +94,7 @@ MessagePrototype.build = function(rebuild) {
     this._fields = [];
     this._fieldsById = {};
     this._fieldsByName = {};
+    this._oneofsByName = {};
     for (var i=0, k=this.children.length, child; i<k; i++) {
         child = this.children[i];
         if (child instanceof Enum || child instanceof Message || child instanceof Service) {
@@ -105,6 +106,9 @@ MessagePrototype.build = function(rebuild) {
             this._fields.push(child),
             this._fieldsById[child.id] = child,
             this._fieldsByName[child.name] = child;
+        else if (child instanceof Message.OneOf) {
+            this._oneofsByName[child.name] = child;
+        }
         else if (!(child instanceof Message.OneOf) && !(child instanceof Extension)) // Not built
             throw Error("Illegal reflect child of "+this.toString(true)+": "+this.children[i].toString(true));
     }

--- a/tests/map.proto
+++ b/tests/map.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+message Inner {
+    int32 num = 1;
+}
+
+message Obj {
+    map<string, Inner> things = 1;
+}

--- a/tests/suite.js
+++ b/tests/suite.js
@@ -263,6 +263,36 @@
             test.deepEqual(t2, t3);
             test.done();
         },
+        
+        "constructorWithOneofs": function(test) {
+            try {
+                var builder = ProtoBuf.loadProtoFile(__dirname+"/oneof.proto"),
+                    MyOneOf = builder.build("MyOneOf"),
+                    TOneOf = builder.lookup(".MyOneOf");
+                test.ok(TOneOf.getChild("my_oneof"));
+                
+                var myOneOf = new MyOneOf();
+                test.strictEqual(myOneOf.my_oneof, null);
+                myOneOf.set("id", 1);
+                test.strictEqual(myOneOf.my_oneof, "id");
+                myOneOf.set("name", "me");
+                test.strictEqual(myOneOf.my_oneof, "name");
+                test.strictEqual(myOneOf.id, null);
+                
+                var copy = new MyOneOf(myOneOf); // this line is what was failing
+                // Error: .MyOneOf#my_oneof is not a field: undefined
+                
+                test.deepEqual(myOneOf, copy);
+                
+                // Test same things are there
+                test.strictEqual(copy.my_oneof, "name");
+                test.strictEqual(copy.name, "me");
+                test.strictEqual(copy.id, null);
+            } catch (e) {
+                fail(e);
+            }
+            test.done();
+        },
 
         "numberFormats": function(test) {
             try {

--- a/tests/suite.js
+++ b/tests/suite.js
@@ -328,6 +328,69 @@
             test.done();
         },
         
+        "constructorDeepCopyWithArray": function(test) {
+            var builder = ProtoBuf.loadProtoFile(__dirname+"/setarray.proto");
+            var Outer = builder.build("Outer");
+            var Inner = builder.build("Inner");
+            
+            var o = new Outer({inners: [{str: "hello"}, {str: "world"}]}),
+                oCopy = new Outer(o);
+                oDecodeCopy = Outer.decode(o.toArrayBuffer());
+            test.deepEqual(o, oCopy);
+            test.deepEqual(o, oDecodeCopy);
+            
+            o.inners[0].str = "hi";
+            
+            test.notEqual(o.inners[0].str, oDecodeCopy.inners[0].str);
+            test.notEqual(o.inners[0].str, oCopy.inners[0].str);
+            
+            // Test copying on add
+            var inner = new Inner("new");
+            o.add("inners", inner);
+            
+            test.equal(inner.str, o.inners[2].str);
+            inner.str = "changed";
+            test.notEqual(inner.str, o.inners[2].str);
+            
+            test.done();
+        },
+        
+        "constructorDeepCopyWithMap": function(test) {
+            var builder = ProtoBuf.loadProtoFile(__dirname+"/map.proto");
+            var Obj = builder.build("Obj");
+            var Key = builder.build("Key");
+            var Inner = builder.build("Inner");
+            
+            var o = new Obj({
+                things: {
+                    "hello": {num: 42},
+                    "world": {num: 57}
+                }
+            });
+            
+            var oCopy = new Obj(o);
+                oDecodeCopy = Obj.decode(o.toArrayBuffer());
+                
+            test.deepEqual(o, oCopy);
+            test.deepEqual(o, oDecodeCopy);
+            
+            o.things.map["hello"].value.num = 3;
+            
+            test.notEqual(o.things.map["hello"].value.num, oDecodeCopy.things.map["hello"].value.num);
+            test.notEqual(o.things.map["hello"].value.num, oCopy.things.map["hello"].value.num);
+            
+            test.equal(o.things.map["hello"].value.num, 3);
+            test.equal(oCopy.things.map["hello"].value.num, 42);
+            
+            var inner = new Inner(8);
+            o.things.set("new", inner);
+            test.equal(inner.num, o.things.map["new"].value.num);
+            inner.num = 9;
+            test.notEqual(inner.num, o.things.map["new"].value.num);
+            
+            test.done();
+        },
+        
         "numberFormats": function(test) {
             try {
                 var builder = ProtoBuf.loadProtoFile(__dirname+"/numberformats.proto");

--- a/tests/suite.js
+++ b/tests/suite.js
@@ -293,7 +293,41 @@
             }
             test.done();
         },
-
+        
+        "constructorShallowCopy": function(test) {
+            var builder = ProtoBuf.loadProtoFile(__dirname+"/example3.proto");
+            var Test1 = builder.build("Test1");
+            var t1 = new Test1({a: 123}),
+                t1Copy = new Test1(t1);
+                t1DecodeCopy = Test1.decode(t1.toArrayBuffer());
+            test.deepEqual(t1, t1Copy);
+            test.deepEqual(t1, t1DecodeCopy);
+            
+            t1.a = 42;
+            
+            test.notEqual(t1.a, t1Copy.a);
+            test.notEqual(t1.a, t1DecodeCopy.a);
+            
+            test.done();
+        },
+        
+        "constructorDeepCopy": function(test) {
+            var builder = ProtoBuf.loadProtoFile(__dirname+"/example3.proto");
+            var Test3 = builder.build("Test3");
+            var t3 = new Test3({c: {a: 123}}),
+                t3Copy = new Test3(t3);
+                t3DecodeCopy = Test3.decode(t3.toArrayBuffer());
+            test.deepEqual(t3, t3Copy);
+            test.deepEqual(t3, t3DecodeCopy);
+            
+            t3.c.a = 42;
+            
+            test.notEqual(t3.c.a, t3Copy.c.a);
+            test.notEqual(t3.c.a, t3DecodeCopy.c.a);
+            
+            test.done();
+        },
+        
         "numberFormats": function(test) {
             try {
                 var builder = ProtoBuf.loadProtoFile(__dirname+"/numberformats.proto");


### PR DESCRIPTION
As suggested in #315 I’ve been trying to use constructors to perform deep copies. (Since I fixed oneofs in #398)
This is necessary for use with React, where messages should be immutable.

However, using the constructor like this only copies top-level values, and not deep nested objects (and array/map contents).

This pull request modifies the set and add functions to perform a deep copy. I think this is the best thing to do – it’s how I instinctively assumed the API would work. It’s similar to how the C++ API works – you have to make copies all the time (or swap). There is no option to make references with the C++ API (how ProtoBuf.js currently works).

However, this is a behaviour change of the public API, so may need to be considered carefully, or left out until a new major release version?
