### PR TITLE
Resolve default values when using message getters

### DIFF
--- a/src/ProtoBuf/Builder/Message.js
+++ b/src/ProtoBuf/Builder/Message.js
@@ -172,7 +172,7 @@ MessagePrototype.get = function(key, noAssert) {
     }
 
     var val = this[fieldName];
-    if (!val) {
+    if (val === null) {
         if (field.type === ProtoBuf.TYPES["message"])
             val = this[field.name] = new (field.resolvedType.clazz)();
         else


### PR DESCRIPTION
What is accomplished in this PR:
1. Resolve default values at access time using the field getters, promoting proper usage of accessors instead of accessing properties directly (I'd prefer if they were made "private" properties).
2. Forward setter to MessagePrototype.set to allow proper handling of oneofs when using generated setters.
3. If a message type field is unset, calling the field's getter will create and retain a new instance of the message. Mimicking the C++ .mutable_{field_name}() and Java .get{FieldName}() behaviors.
4. Added a "has" field methods to check whether or not a field has been set or if it is still equivalent to it's default value.
5. All tests pass without modification. These changes should be fairly non-invasive for existing projects.
