### PR TITLE
pbjs: Util.isDescriptor should explicitly match `google/protobuf/descriptor`

### DIFF
--- a/cli/pbjs/util.js
+++ b/cli/pbjs/util.js
@@ -124,5 +124,5 @@ util.groupExtensions = function(ns) {
  * @returns {boolean}
  */
 util.isDescriptor = function(name) {
-    return /^google\/protobuf\//.test(name);
+    return /^google\/protobuf\/descriptor/.test(name);
 };


### PR DESCRIPTION
The pbjs CLI tool is naively matching all `google/protobuf` imports, which prevents the use of other Google well-known types.  For instance, some of our messages reference items out of `google/protobuf/struct` and no matter how we specify import paths, the created builder always looks within the same folder as the referencing `proto` file for the imported google types.  This is because `util.isDescriptor(imports[i])` returns `true` for any Google imports (in `json.js` on line 67), so the file isn't resolved properly.

It's possible my own solution is a bit naive, but altering the regex does fix my problem, and it passes any tests that exist (although I'm not sure there are tests around `pbjs`).

Thanks!