### PR TITLE
Better error messages

### DIFF
--- a/dist/protobuf-light.js
+++ b/dist/protobuf-light.js
@@ -801,9 +801,11 @@
          * converted to string form if so.
          * @param {string} syntax Syntax level of defining message type, e.g.,
          * proto2 or proto3.
+         * @param {string} name Name of the field containing this element (for error
+         * messages)
          * @constructor
          */
-        var Element = function(type, resolvedType, isMapKey, syntax) {
+        var Element = function(type, resolvedType, isMapKey, syntax, name) {
 
             /**
              * Element type, as a string (e.g., int32).
@@ -828,6 +830,12 @@
              * @type {string}
              */
             this.syntax = syntax;
+
+            /**
+             * Name of the field containing this element (for error messages)
+             * @type {string}
+             */
+            this.name = name;
 
             if (isMapKey && ProtoBuf.MAP_KEY_TYPES.indexOf(type) < 0)
                 throw Error("Invalid map key type: " + type.name);
@@ -877,6 +885,10 @@
             if (typeof value === 'number')
                 return ProtoBuf.Long.fromNumber(value, unsigned || false);
             throw Error("not convertible to Long");
+        }
+
+        ElementPrototype.toString = function() {
+            return (this.name || '') + (this.isMapKey ? 'map' : 'value') + ' element';
         }
 
         /**
@@ -2503,9 +2515,9 @@
          * @expose
          */
         FieldPrototype.build = function() {
-            this.element = new Element(this.type, this.resolvedType, false, this.syntax);
+            this.element = new Element(this.type, this.resolvedType, false, this.syntax, this.name);
             if (this.map)
-                this.keyElement = new Element(this.keyType, undefined, true, this.syntax);
+                this.keyElement = new Element(this.keyType, undefined, true, this.syntax, this.name);
 
             // In proto3, fields do not have field presence, and every field is set to
             // its type's default value ("", 0, 0.0, or false).

--- a/dist/protobuf.js
+++ b/dist/protobuf.js
@@ -1103,7 +1103,11 @@
                 else if (token === "service")
                     this._parseService(msg);
                 else if (token === "extensions")
-                    msg["extensions"] = this._parseExtensionRanges();
+                    if (msg.hasOwnProperty("extensions")) {
+                        msg["extensions"] = msg["extensions"].concat(this._parseExtensionRanges())
+                    } else {
+                        msg["extensions"] = this._parseExtensionRanges();
+                    }
                 else if (token === "reserved")
                     this._parseIgnored(); // TODO
                 else if (token === "extend")
@@ -1709,9 +1713,11 @@
          * converted to string form if so.
          * @param {string} syntax Syntax level of defining message type, e.g.,
          * proto2 or proto3.
+         * @param {string} name Name of the field containing this element (for error
+         * messages)
          * @constructor
          */
-        var Element = function(type, resolvedType, isMapKey, syntax) {
+        var Element = function(type, resolvedType, isMapKey, syntax, name) {
 
             /**
              * Element type, as a string (e.g., int32).
@@ -1736,6 +1742,12 @@
              * @type {string}
              */
             this.syntax = syntax;
+
+            /**
+             * Name of the field containing this element (for error messages)
+             * @type {string}
+             */
+            this.name = name;
 
             if (isMapKey && ProtoBuf.MAP_KEY_TYPES.indexOf(type) < 0)
                 throw Error("Invalid map key type: " + type.name);
@@ -1785,6 +1797,10 @@
             if (typeof value === 'number')
                 return ProtoBuf.Long.fromNumber(value, unsigned || false);
             throw Error("not convertible to Long");
+        }
+
+        ElementPrototype.toString = function() {
+            return (this.name || '') + (this.isMapKey ? 'map' : 'value') + ' element';
         }
 
         /**
@@ -3411,9 +3427,9 @@
          * @expose
          */
         FieldPrototype.build = function() {
-            this.element = new Element(this.type, this.resolvedType, false, this.syntax);
+            this.element = new Element(this.type, this.resolvedType, false, this.syntax, this.name);
             if (this.map)
-                this.keyElement = new Element(this.keyType, undefined, true, this.syntax);
+                this.keyElement = new Element(this.keyType, undefined, true, this.syntax, this.name);
 
             // In proto3, fields do not have field presence, and every field is set to
             // its type's default value ("", 0, 0.0, or false).

--- a/src/ProtoBuf/Reflect/Element.js
+++ b/src/ProtoBuf/Reflect/Element.js
@@ -15,9 +15,11 @@
  * converted to string form if so.
  * @param {string} syntax Syntax level of defining message type, e.g.,
  * proto2 or proto3.
+ * @param {string} name Name of the field containing this element (for error
+ * messages)
  * @constructor
  */
-var Element = function(type, resolvedType, isMapKey, syntax) {
+var Element = function(type, resolvedType, isMapKey, syntax, name) {
 
     /**
      * Element type, as a string (e.g., int32).
@@ -42,6 +44,12 @@ var Element = function(type, resolvedType, isMapKey, syntax) {
      * @type {string}
      */
     this.syntax = syntax;
+
+    /**
+     * Name of the field containing this element (for error messages)
+     * @type {string}
+     */
+    this.name = name;
 
     if (isMapKey && ProtoBuf.MAP_KEY_TYPES.indexOf(type) < 0)
         throw Error("Invalid map key type: " + type.name);
@@ -91,6 +99,10 @@ function mkLong(value, unsigned) {
     if (typeof value === 'number')
         return ProtoBuf.Long.fromNumber(value, unsigned || false);
     throw Error("not convertible to Long");
+}
+
+ElementPrototype.toString = function() {
+    return (this.name || '') + (this.isMapKey ? 'map' : 'value') + ' element';
 }
 
 /**

--- a/src/ProtoBuf/Reflect/Message/Field.js
+++ b/src/ProtoBuf/Reflect/Message/Field.js
@@ -141,9 +141,9 @@ var FieldPrototype = Field.prototype = Object.create(T.prototype);
  * @expose
  */
 FieldPrototype.build = function() {
-    this.element = new Element(this.type, this.resolvedType, false, this.syntax);
+    this.element = new Element(this.type, this.resolvedType, false, this.syntax, this.name);
     if (this.map)
-        this.keyElement = new Element(this.keyType, undefined, true, this.syntax);
+        this.keyElement = new Element(this.keyType, undefined, true, this.syntax, this.name);
 
     // In proto3, fields do not have field presence, and every field is set to
     // its type's default value ("", 0, 0.0, or false).

--- a/tests/suite.js
+++ b/tests/suite.js
@@ -674,6 +674,18 @@
             test.done();
         },
 
+        // Test error messages
+        "errorMessage": function(test) {
+            test.throws(function() {
+                var builder = ProtoBuf.loadJsonFile(__dirname+"/complex.json");
+                var Game = builder.build("Game");
+                var car = new Game.Cars.Car();
+                car.speed = "hello";
+                car.encode();
+            }, /Illegal value for speed/);
+            test.done();
+        },
+
         // Builder reused to add definitions from multiple sources
         "multiBuilder": function(test) {
             try {


### PR DESCRIPTION
If encoding a field fails, protobuf.js throws an error like "Illegal value for [object Object]."  This updates Element to instead give the field name.

Fixes #422.