### PR TITLE
update reference to js to copy for running the example

### DIFF
--- a/examples/websocket/server.js
+++ b/examples/websocket/server.js
@@ -8,9 +8,9 @@ var http = require("http"),
 
 // Copy dependencies to "www/" (example specific, you usually don't have to care
 var deps = [
-    ["Long.min.js", "./node_modules/protobufjs/node_modules/bytebuffer/node_modules/long/dist/Long.min.js"],
-    ["ByteBufferAB.min.js", "./node_modules/protobufjs/node_modules/bytebuffer/dist/ByteBufferAB.min.js"],
-    ["ProtoBuf.min.js", "./node_modules/protobufjs/dist/ProtoBuf.min.js"]
+      ["Long.min.js", "./node_modules/long/dist/Long.min.js"],
+      ["ByteBufferAB.min.js", "./node_modules/bytebuffer/dist/ByteBufferAB.min.js"],
+      ["ProtoBuf.min.js", "./node_modules/protobufjs/dist/ProtoBuf.min.js"]
 ];
 for (var i=0, dep, data; i<deps.length; i++) {
     dep = deps[i];
@@ -68,7 +68,7 @@ server.on("error", function(err) {
     console.log("Failed to start server:", err);
     process.exit(1);
 });
-    
+
 // WebSocket adapter
 var wss = new ws.Server({server: server});
 wss.on("connection", function(socket) {


### PR DESCRIPTION
When I tried to run the websocket example it returned me an error because it was looking for long.min.js, ByteBuffer.min.js and Protobuf.min.js in a wrong folder. 

