### PR TITLE
Update dep to glob@7.0.5 (security reasons)

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "ascli": "~1",
     "bytebuffer": "~5",
-    "glob": "^5.0.10",
+    "glob": "^7.0.5",
     "yargs": "^3.10.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Glob library uses `minimatch` library which has a security vulnerability https://nodesecurity.io/advisories/118

Glob already updated its dependency version to a secure one. This change is to update glob dependency to that version.

All the tests are passing.