### PR TITLE
Make repeated fields packed by default in proto3

### DIFF
--- a/dist/protobuf-light.js
+++ b/dist/protobuf-light.js
@@ -3883,6 +3883,16 @@
                     this.ptr.keyType = ProtoBuf.TYPES[this.ptr.keyType];
                 }
 
+                // If it's a repeated and packable field then proto3 mandates it should be packed by
+                // default
+                if (
+                  this.ptr.syntax === 'proto3' &&
+                  this.ptr.repeated && this.ptr.options.packed === undefined &&
+                  ProtoBuf.PACKABLE_WIRE_TYPES.indexOf(this.ptr.type.wireType) !== -1
+                ) {
+                  this.ptr.options.packed = true;
+                }
+
             } else if (this.ptr instanceof ProtoBuf.Reflect.Service.Method) {
 
                 if (this.ptr instanceof ProtoBuf.Reflect.Service.RPCMethod) {

--- a/dist/protobuf.js
+++ b/dist/protobuf.js
@@ -4795,6 +4795,16 @@
                     this.ptr.keyType = ProtoBuf.TYPES[this.ptr.keyType];
                 }
 
+                // If it's a repeated and packable field then proto3 mandates it should be packed by
+                // default
+                if (
+                  this.ptr.syntax === 'proto3' &&
+                  this.ptr.repeated && this.ptr.options.packed === undefined &&
+                  ProtoBuf.PACKABLE_WIRE_TYPES.indexOf(this.ptr.type.wireType) !== -1
+                ) {
+                  this.ptr.options.packed = true;
+                }
+
             } else if (this.ptr instanceof ProtoBuf.Reflect.Service.Method) {
 
                 if (this.ptr instanceof ProtoBuf.Reflect.Service.RPCMethod) {

--- a/src/ProtoBuf/Builder.js
+++ b/src/ProtoBuf/Builder.js
@@ -521,6 +521,16 @@ ProtoBuf.Builder = (function(ProtoBuf, Lang, Reflect) {
                 this.ptr.keyType = ProtoBuf.TYPES[this.ptr.keyType];
             }
 
+            // If it's a repeated and packable field then proto3 mandates it should be packed by
+            // default
+            if (
+              this.ptr.syntax === 'proto3' &&
+              this.ptr.repeated && this.ptr.options.packed === undefined &&
+              ProtoBuf.PACKABLE_WIRE_TYPES.indexOf(this.ptr.type.wireType) !== -1
+            ) {
+              this.ptr.options.packed = true;
+            }
+
         } else if (this.ptr instanceof ProtoBuf.Reflect.Service.Method) {
 
             if (this.ptr instanceof ProtoBuf.Reflect.Service.RPCMethod) {


### PR DESCRIPTION
This is required for compatibility with existing proto3 definitions. See #432