### PR TITLE
pbjs: write RPC method stream info to JSON output

### DIFF
--- a/cli/pbjs/targets/json.js
+++ b/cli/pbjs/targets/json.js
@@ -245,7 +245,9 @@ function buildService(svc) {
     svc.getChildren(ProtoBuf.Reflect.Service.RPCMethod).forEach(function(mtd) {
         rpc[mtd.name] = {
             "request": svc.qn(mtd.resolvedRequestType),
+            "request_stream": mtd.requestStream,
             "response": svc.qn(mtd.resolvedResponseType),
+            "response_stream": mtd.responseStream,
             "options": buildOptions(mtd.options)
         };
     });


### PR DESCRIPTION
The pbjs tool currently does not export RPC method stream information to the JSON format, however, the Builder expects it in the JSON input. This is fixed by setting `request_stream` and `response_stream` in the JSON output of pbjs.

Fixes #468

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dcodeio/protobuf.js/470)
<!-- Reviewable:end -->
