### PR TITLE
fix util.fetch method did not send the xhr.

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -131,6 +131,7 @@ function fetch(path, callback) {
         return callback(Error("request failed"));
     };
     xhr.open("GET", path, true);
+    xhr.send();
     return undefined;
 }
 


### PR DESCRIPTION
A little mistake of util.fetch method in browser.When using xhr,the old code forgot to run xhr.send() to make the request send out,and i add it now.