### PR TITLE
Builder: Use path.join when running on Node

### DIFF
--- a/src/ProtoBuf/Builder.js
+++ b/src/ProtoBuf/Builder.js
@@ -377,7 +377,11 @@ ProtoBuf.Builder = (function(ProtoBuf, Lang, Reflect) {
                 root = require("path")['resolve'](root);
             if (root.indexOf("\\") >= 0 || filename.file.indexOf("\\") >= 0)
                 delim = '\\';
-            var fname = root + delim + filename.file;
+            var fname;
+            if (ProtoBuf.Util.IS_NODE)
+                fname = require("path")['join'](root, filename.file);
+            else
+                fname = root + delim + filename.file;
             if (this.files[fname] === true)
                 return this.reset();
             this.files[fname] = true;
@@ -423,7 +427,10 @@ ProtoBuf.Builder = (function(ProtoBuf, Lang, Reflect) {
                     var importFilename = json['imports'][i];
                     if (importFilename === "google/protobuf/descriptor.proto")
                         continue; // Not needed and therefore not used
-                    importFilename = importRoot + delim + importFilename;
+                    if (ProtoBuf.Util.IS_NODE)
+                        importFilename = require("path")['join'](importRoot, importFilename);
+                    else
+                        importFilename = importRoot + delim + importFilename;
                     if (this.files[importFilename] === true)
                         continue; // Already imported
                     if (/\.proto$/i.test(importFilename) && !ProtoBuf.DotProto)       // If this is a light build


### PR DESCRIPTION
path.join correctly handles edge cases, such as if the import root is `/`. In this case, path.join correctly returns the path of `/filename` instead of `//filename`.