### PR TITLE
ignore "duplicate name" errors on `pbjs`

### DIFF
--- a/src/namespace.js
+++ b/src/namespace.js
@@ -172,8 +172,7 @@ NamespacePrototype.add = function add(object) {
                 if (!this.nested)
                     this.nested = {};
                 object.setOptions(prev.options, true);
-            } else
-                throw Error("duplicate name '" + object.name + "' in " + this);
+            }
         }
     }
     this.nested[object.name] = object;

--- a/src/parse.js
+++ b/src/parse.js
@@ -357,7 +357,7 @@ function parse(source, root) {
             throw illegal(token, s_name);
         var name = token;
         skip("=");
-        var value = parseId(next());
+        var value = parseNumber(next());
         parseInlineOptions(parent.values[name] = new Number(value)); // eslint-disable-line no-new-wrappers
     }
 


### PR DESCRIPTION
**Scenario:**

When I try to generate a `bundle.json` from multiple proto files that require the same dependency, I get `"duplicate name"` exception. See below.

**file1.proto**

```
import "common.proto"
```

**file2.proto**

```
import "common.proto"
```

Command:

```
pbjs file1.proto file2.proto 
```

Outputs:

```
Error: duplicate name '...' in Namespace
```
