### PR TITLE
Disambiguation for `load` interface

### DIFF
--- a/types/protobuf.js.d.ts
+++ b/types/protobuf.js.d.ts
@@ -322,7 +322,10 @@ declare module "protobufjs" {
     * @returns {Promise<Root>|Object} A promise if callback has been omitted, otherwise the protobuf namespace
     * @throws {TypeError} If arguments are invalid
     */
-   function load(filename: (string|string[]), root?: Root, callback?: any): (Promise<Root>|Object);
+   function load(filename: (string|string[]), root: Root, callback: (err?: Error, root: Root=) => any): Object;
+   function load(filename: (string|string[]), callback: (err?: Error, root: Root=) => any): Object;
+   function load(filename: (string|string[])): Promise<Root>;
+
    
    /**
     * Options passed to {@link inherits}, modifying its behavior.


### PR DESCRIPTION
This change allows the typechecker to know the type that is going to be returned.