### PR TITLE
make type definition of load function userfriendly

### DIFF
--- a/types/protobuf.js.d.ts
+++ b/types/protobuf.js.d.ts
@@ -322,7 +322,10 @@ declare module "protobufjs" {
     * @returns {Promise<Root>|undefined} A promise if `callback` has been omitted
     * @throws {TypeError} If arguments are invalid
     */
-   function load(filename: (string|string[]), root?: (Root|any), callback?: any): (Promise<Root>|undefined);
+   function load(filename: (string|string[])): Promise<Root>;
+   function load(filename: (string|string[]), callback: (err: any, root: Root) => any): Object;
+   function load(filename: (string|string[]), root: Root): Promise<Root>;
+   function load(filename: (string|string[]), root: Root, callback: (err: any, root: Root) => any): Object;
    
    /**
     * Options passed to {@link inherits}, modifying its behavior.
@@ -1194,7 +1197,8 @@ declare module "protobufjs" {
        * @returns {Promise<Root>|undefined} A promise if `callback` has been omitted
        * @throws {TypeError} If arguments are invalid
        */
-      load(filename: (string|string[]), callback?: any): (Promise<Root>|undefined);
+      load(filename: (string|string[])): Promise<Root>;
+      load(filename: (string|string[]), callback: (err: any, root: Root): void;
    
    }
    


### PR DESCRIPTION
### TL;DR
I know this file is generated, but returning an intersection type is really inconvenient.
So please see this more like a discussion starter on how the typing files could be improved.

## Description

This PR intentionally modifies a generated file to highlight that using multiple function overload definitions greatly improve user experience, especially when returning different types depending on the input parameters.

### before
![original](https://cloud.githubusercontent.com/assets/4932/20981805/53818ce8-bcb6-11e6-8be7-1d8df71b57d8.png)
![returning-object](https://cloud.githubusercontent.com/assets/4932/20981810/580bd55c-bcb6-11e6-800d-aa3c64524234.png)

### after
![listing-different-signatures](https://cloud.githubusercontent.com/assets/4932/20981819/5f5efe60-bcb6-11e6-84f4-b2a241f40d36.png)
![autocomplete-promise](https://cloud.githubusercontent.com/assets/4932/20981825/62200f36-bcb6-11e6-810c-09b61f27f77b.png)


There's still lots of room for improvement beyond this tiny PR, but I wonder what would be a good way for this great project to gain better typings than those generated currently.

/cc @endel - what's your take as one who already contributed TS improvements?

