### PR TITLE
Fixed Root Initialization

### DIFF
--- a/cli/wrappers/static-module.js
+++ b/cli/wrappers/static-module.js
@@ -13,6 +13,7 @@
 
     %OUTPUT%
 
+    $protobuf.roots = {};
     $protobuf.roots[%ROOT%] = $root;
 
     return $root;


### PR DESCRIPTION
`roots` is undefined and the loading throws an error. This fixes that issue.