### PR TITLE
Bugfix: Prefix generated static variables to avoid reserved keyword clashing

### DIFF
--- a/cli/targets/static.js
+++ b/cli/targets/static.js
@@ -101,7 +101,7 @@ function buildNamespace(ref, ns) {
             "@exports " + ns.fullName.substring(1),
             "@namespace"
         ]);
-        push("var " + name(ns.name) + " = {};");
+        push("var $" + name(ns.name) + " = {};");
     }
 
     ns.nestedArray.forEach(function(nested) {


### PR DESCRIPTION
I noticed earlier while playing around with this library that if a protobuf file namespace has reserved keywords, then a variables are generated with reserved keyword names. Importing the file then causes errors.

```proto
syntax = 'proto3';

package var.for.switch;

message Sampler {
	string sample = 1;
}
```

Compiling this and `requiring` it gives the following:

```
var var = {};
            ^^^
SyntaxError: Unexpected token var
```

To get around this, I simply prefixed the generated variable name with `$`, which seemed to be in keeping with the conventions of this library. These variables are generated within closures, so they are not assigned anywhere that they may be accessed by a consumer of the generated code.

I understand that this fix may be over-simplified, so I'm happy to work on a better solution than this. I also understand that there are no tests for this module yet, but if some were added, I'd be happy to contribute a test case for this.