### PR TITLE
Support pool usage when size = 0

### DIFF
--- a/src/util/pool/index.js
+++ b/src/util/pool/index.js
@@ -34,7 +34,7 @@ function pool(alloc, slice, size) {
     var slab   = null;
     var offset = SIZE;
     return function pool_alloc(size) {
-        if (size > MAX)
+        if (size > MAX || size === 0)
             return alloc(size);
         if (offset + size > SIZE) {
             slab = alloc(SIZE);


### PR DESCRIPTION
I got an error when encoding an empty message (`{}`).
When the message is empty,  the size is 0 and `slab` is null, so`slice.call(slab, offset, offset += size);` gave me
```
Uncaught TypeError: Method get TypedArray.prototype.subarray called on incompatible receiver null
```
Adding this solved the issue for me. Please correct me if I was using it all wrong. :joy: