### PR TITLE
Fix directly using Buffer instead of util.Buffer

### DIFF
--- a/src/field.js
+++ b/src/field.js
@@ -287,7 +287,7 @@ FieldPrototype.jsonConvert = function(value, options) {
             if (options.bytes === Array)
                 return Array.prototype.slice.call(value);
             if (options.bytes === util.Buffer && !util.Buffer.isBuffer(value))
-                return util.Buffer.from ? util.Buffer.from(value) : new Buffer(value);
+                return util.Buffer.from ? util.Buffer.from(value) : new util.Buffer(value);
         }
     }
     return value;


### PR DESCRIPTION
This seems to have caused webpack to load a Buffer shim when building for web.