### PR TITLE
Changes callback on failed response decode in rpc service

### DIFF
--- a/src/rpc/service.js
+++ b/src/rpc/service.js
@@ -118,7 +118,7 @@ Service.prototype.rpcCall = function rpcCall(method, requestCtor, responseCtor, 
                         response = responseCtor[self.responseDelimited ? "decodeDelimited" : "decode"](response);
                     } catch (err) {
                         self.emit("error", err, method);
-                        return callback("error", err);
+                        return callback(err);
                     }
                 }
 


### PR DESCRIPTION
Currently, the string "error" is passed to the callback on response decode errors (with the actual error passed where the decoded response would normally be). 

This updates the rpc service to pass the error as the first param to the callback.