### PR TITLE
add support for node 4.2.0 to 4.4.7 with specific buffer polyfill

### DIFF
--- a/src/util/minimal.js
+++ b/src/util/minimal.js
@@ -70,6 +70,24 @@ util.Buffer = (function() {
         if (!Buffer.prototype.utf8Write) // refuse to use non-node buffers (performance)
             return null;
 
+        // Node 4.2.0 to 4.4.7 Support.  Unfortunatly not 4.0.0 - 4.1.2 compatible
+        // See - https://github.com/nodejs/node/pull/3080 for reference
+        if (Buffer.from && Buffer.from.toString() === Uint8Array.from.toString()) {
+          function PolyBuffer(arg, encoding) {
+            var b = new Buffer(arg, encoding);
+            Object.setPrototypeOf(b, PolyBuffer.prototype);
+            return b;
+          }
+
+          PolyBuffer.from = function(value, encoding) { return new PolyBuffer(value, encoding); };
+          PolyBuffer.allocUnsafe = function allocUnsafe(size) { return new PolyBuffer(size); };
+
+          Object.setPrototypeOf(PolyBuffer.prototype, Buffer.prototype);
+          Object.setPrototypeOf(PolyBuffer, Buffer);
+
+          return PolyBuffer;
+        }
+
         /* istanbul ignore next */
         if (!Buffer.from)
             Buffer.from = function from(value, encoding) { return new Buffer(value, encoding); };


### PR DESCRIPTION
This PR enables support for Node 4.3.2 (which I'm stuck with on AWS Lambda).

The `Buffer` object in Node 4.0, 4.1, 4.1, and 4.4 have a `Buffer.from` method defined which is inherited from `Uint8Array`.  The current polyfill only checks if `from` is present and the `from` method in these versions accept a typed array as an argument, which doesn't behave nicely.

This PR replaces `util.Buffer` with a new object on those node versions and brings compatibility to Node 4.2.0 to 4.4.7.  Unfortunately, `Buffer` can't be inherited from on 4.0 and 4.1, so this polyfill doesn't work there.

Ran tests locally with node 4.3.2 and they all passed and I'm also using this PR to decode protobuf messages in lambda through the static code generation.

Maybe node 4.3.2 should be added to travis to prevent regression?