### PR TITLE
Full support for reserved type

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -147,6 +147,39 @@ function parse(source, root, options) {
         return [ start, end ];
     }
 
+    function readReserved(){
+      var r_list = [];
+      var val;
+      var add_range = false;
+      var i;
+
+      while( !skip( ';', true ) ){
+
+        skip( ",", true );
+
+        if( !skip( 'to', true ) ){
+
+          val = readValue();
+
+          /* add each val between last and val*/
+          if( add_range ){
+            for ( i = r_list[ r_list.length - 1 ] + 1; i < val; i += 1 ){
+              r_list.push( i );
+            }
+            add_range = false;
+          }
+
+          r_list.push( val );
+        }
+        else{
+          /*will need to add each value between last val and next*/
+          add_range = true;
+        }
+      }
+
+      return r_list;
+    }
+
     function parseNumber(token, insideTryCatch) {
         var sign = 1;
         if (token.charAt(0) === "-") {
@@ -294,7 +327,7 @@ function parse(source, root, options) {
                         break;
 
                     case "reserved":
-                        (type.reserved || (type.reserved = [])).push(readRange(type, tokenLower));
+                        (type.reserved || (type.reserved = [])).push(readReserved(type, tokenLower));
                         break;
 
                     default:


### PR DESCRIPTION
Only this case was being handled:

`reserved 10 to 20;`

But all of the following are valid ([source](https://developers.google.com/protocol-buffers/docs/reference/proto3-spec#reserved)):

```
reserved 2, 15, 9 to 11;
reserved "foo", "bar";
```

Files with reserved names or comma separated numbers would not compile. This is my attempt to handle all cases in a way that is consistent with the existing codebase.