### PR TITLE
handle allow_alias option for Enums

### DIFF
--- a/src/enum.js
+++ b/src/enum.js
@@ -91,7 +91,7 @@ Enum.prototype.add = function(name, id, comment) {
     if (this.values[name] !== undefined)
         throw Error("duplicate name");
 
-    if (this.valuesById[id] !== undefined)
+    if (this.valuesById[id] !== undefined && !(this.options && this.options.allow_alias))
         throw Error("duplicate id");
 
     this.valuesById[this.values[name] = id] = name;

--- a/tests/api_enum.js
+++ b/tests/api_enum.js
@@ -9,6 +9,9 @@ tape.test("reflected enums", function(test) {
         b: 2
     });
 
+    var enm_allow_alias = new protobuf.Enum( 'AliasTest',
+    { a: 0 }, { allow_alias: true } );
+
     test.throws(function() {
         new protobuf.Enum("Test", true);
     }, TypeError, "should throw if values is specified but not an object");
@@ -32,7 +35,7 @@ tape.test("reflected enums", function(test) {
 
     test.throws(function() {
         enm.add("c", 2);
-    }, Error, "should throw if id is a duplicate");
+    }, Error, "should throw if id is a duplicate, without allow_alias option");
 
     enm.add("c", 3);
     test.same(enm.values, {
@@ -71,6 +74,12 @@ tape.test("reflected enums", function(test) {
             c: 3
         }
     }, "should export options and values to JSON");
+
+    enm_allow_alias.add( 'b', 0 );
+    test.same( enm_allow_alias.values, {
+      a: 0,
+      b: 0
+    });
 
     test.end();
 });


### PR DESCRIPTION
Duplicate enum IDs threw an exception, even if the `allow_alias` option was set to true. Pull request to handle this condition. Also added a test case.