### PR TITLE
Update parse.js

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -336,7 +336,7 @@ function parse(source, root, options) {
             field.comment = cmnt(trailingLine);
         // JSON defaults to packed=true if not set so we have to set packed=false explicity when
         // parsing proto2 descriptors without the option, where applicable.
-        if (field.repeated && types.packed[type] !== undefined && !isProto3)
+        if (field.repeated && !isProto3)
             field.setOption("packed", false, /* ifNotSet */ true);
         parent.add(field);
     }


### PR DESCRIPTION
This check is wrong as the types.packed fields includes only the built in primitive types. But at this point type of the repeated enum is a custom type like test.TestMessage therefore types.packed[type] !== undefined always returns false and code never enters that if condition and it does not set the packed flag to false. However when the syntax is set to proto2 this flag should be always set to false.