### PR TITLE
Fixing the packed=true by default problem for proto2 files.

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -336,7 +336,8 @@ function parse(source, root, options) {
             field.comment = cmnt(trailingLine);
         // JSON defaults to packed=true if not set so we have to set packed=false explicity when
         // parsing proto2 descriptors without the option, where applicable.
-        if (field.repeated && !isProto3)
+        var packed = field.getOption('packed');
+        if (field.repeated && packed === undefined && !isProto3)
             field.setOption("packed", false, /* ifNotSet */ true);
         parent.add(field);
     }

--- a/src/parse.js
+++ b/src/parse.js
@@ -336,7 +336,7 @@ function parse(source, root, options) {
             field.comment = cmnt(trailingLine);
         // JSON defaults to packed=true if not set so we have to set packed=false explicity when
         // parsing proto2 descriptors without the option, where applicable.
-        if (field.repeated && types.packed[type] !== undefined && !isProto3)
+        if (field.repeated && !isProto3)
             field.setOption("packed", false, /* ifNotSet */ true);
         parent.add(field);
     }


### PR DESCRIPTION
Fixing the packed=true by default problem for proto2 files. Packed should be false by default for repeated enums when the syntax is set to proto2.