### PR TITLE
Mark optional fields as possibly being undefined

### DIFF
--- a/cli/targets/static.js
+++ b/cli/targets/static.js
@@ -208,7 +208,7 @@ function buildFunction(type, functionName, gen, scope) {
 
     if (config.beautify)
         code = beautifyCode(code);
-    
+
     code = code.replace(/ {4}/g, "\t");
 
     var hasScope = scope && Object.keys(scope).length;
@@ -307,7 +307,7 @@ function buildType(ref, type) {
             pushComment([
                 field.comment || type.name + " " + field.name + ".",
                 prop.charAt(0) !== "." ? "@name " + fullName + "#" + field.name : null,
-                "@type {" + jsType + "}"
+                "@type {" + jsType + (field.optional ? "|undefined": "") + "}"
             ]);
         } else if (firstField) {
             push("");
@@ -389,7 +389,7 @@ function buildType(ref, type) {
             --indent;
         push("};");
     }
-    
+
     if (config.encode) {
         push("");
         pushComment([

--- a/lib/tsd-jsdoc/publish.js
+++ b/lib/tsd-jsdoc/publish.js
@@ -314,6 +314,18 @@ function writeInterface(element) {
 
 // handles a single element of any understood type
 function handleElement(element, parent, insideClass) {
+    if (element.optional !== true && element.type && element.type.names && element.type.names.length) {
+        for (let i = 0; i < element.type.names.length; i++) {
+            if (element.type.names[i].toLowerCase() === 'undefined') {
+                // This element is actually optional. Set optional to true and
+                // remove the 'undefined' type
+                element.optional = true;
+                element.type.names.splice(i, 1);
+                i--;
+            }
+        }
+    }
+
     if (seen[element.longname])
         return true;
     if (isClassLike(element)) {
@@ -460,7 +472,10 @@ function handleMember(element, parent) {
         } else
             write(element.kind === "constant" ? "const " : "var ");
 
-        write(element.name, ": ");
+        write(element.name);
+        if (element.optional)
+            write("?");
+        write(": ");
 
         if (element.type && element.type.names && /^Object\b/i.test(element.type.names[0]) && element.properties) {
             writeln("{");


### PR DESCRIPTION
This PR will allow TS generated code to properly show when class members are potentially undefined.

If this is alright to merge, what is the quickest way to regenerate the tests/data files to reflect the changes?