### PR TITLE
fix: pass output to callback if out is not a file

### DIFF
--- a/cli/pbjs.js
+++ b/cli/pbjs.js
@@ -278,11 +278,11 @@ exports.main = function main(args, callback) {
             if (output !== "") {
                 if (argv.out)
                     fs.writeFileSync(argv.out, output, { encoding: "utf8" });
-                else
+                else if (!callback)
                     process.stdout.write(output, "utf8");
             }
             return callback
-                ? callback(null)
+                ? argv.out ? callback(null) : callback(null, output)
                 : undefined;
         });
     }


### PR DESCRIPTION
Currently, the output is not passed to the callback if the output target is not a file. It is written to stdout even with programmatic access.

This pull request fixes that by only writing to stdout if invoked non-programmatically and only passing the output to the callback if the target is not a file.

fixes #724 