### PR TITLE
Update TypeScript default values for proto3 syntax

### DIFF
--- a/cli/targets/static.js
+++ b/cli/targets/static.js
@@ -341,6 +341,7 @@ function toJsType(field) {
 /**
  * If the given field will have a default value assigned to it by a Proto3 lib
  * @param {Field} field
+ * @returns {boolean}
  */
 function willFieldHaveDefaultValue(field) {
     if (field.repeated || field.map) {

--- a/cli/targets/static.js
+++ b/cli/targets/static.js
@@ -44,7 +44,7 @@ function static_target(root, options, callback) {
         }
         var rootProp = cliUtil.safeProp(config.root || "default");
         push((config.es6 ? "const" : "var") + " $root = $protobuf.roots" + rootProp + " || ($protobuf.roots" + rootProp + " = {});");
-        buildNamespace(null, root);
+        buildNamespace(null, root, root);
         return callback(null, out.join("\n"));
     } catch (err) {
         return callback(err);
@@ -92,7 +92,7 @@ function aOrAn(name) {
         : "a ") + name;
 }
 
-function buildNamespace(ref, ns) {
+function buildNamespace(ref, ns, root) {
     if (!ns)
         return;
     if (ns.name !== "") {
@@ -105,7 +105,7 @@ function buildNamespace(ref, ns) {
     }
 
     if (ns instanceof Type) {
-        buildType(undefined, ns);
+        buildType(undefined, ns, root);
     } else if (ns instanceof Service)
         buildService(undefined, ns);
     else if (ns.name !== "") {
@@ -122,7 +122,7 @@ function buildNamespace(ref, ns) {
         if (nested instanceof Enum)
             buildEnum(ns.name, nested);
         else if (nested instanceof Namespace)
-            buildNamespace(ns.name, nested);
+            buildNamespace(ns.name, nested, root);
     });
     if (ns.name !== "") {
         push("");
@@ -338,7 +338,26 @@ function toJsType(field) {
          : type;
 }
 
-function buildType(ref, type) {
+/**
+ * If the given field will have a default value assigned to it by a Proto3 lib
+ * @param {Field} field
+ */
+function willFieldHaveDefaultValue(field) {
+    if (field.repeated || field.map) {
+        // Default value being an empty array or map
+        return true;
+    }
+
+    field.resolve();
+    if (!field.resolvedType || field.resolvedType instanceof Enum) {
+        // Enums default to 0
+        return true;
+    }
+
+    return false;
+}
+
+function buildType(ref, type, root) {
     var fullName = type.fullName.substring(1);
 
     if (config.comments) {
@@ -372,11 +391,18 @@ function buildType(ref, type) {
     type.fieldsArray.forEach(function(field) {
         field.resolve();
         var prop = util.safeProp(field.name);
+        var canFieldBeUndefined = field.optional;
+        if (root.containsProto3) {
+            // Only fields not given defaults can be undefined since proto3 has
+            // no "optional" or "required" fields
+            canFieldBeUndefined = !willFieldHaveDefaultValue(field);
+        }
+
         if (config.comments) {
             push("");
             pushComment([
                 field.comment || type.name + " " + field.name + ".",
-                "@type {" + toJsType(field) + (field.optional ? "|undefined" : "") + "}"
+                "@type {" + toJsType(field) + (canFieldBeUndefined ? "|null" : "") + "}"
             ]);
         } else if (firstField) {
             push("");

--- a/src/parse.js
+++ b/src/parse.js
@@ -86,6 +86,11 @@ function parse(source, root, options) {
         syntax,
         isProto3 = false;
 
+    /**
+     * If proto3 syntax was used at any point in the source
+     */
+    var sourceContainsProto3 = false;
+
     var ptr = root;
 
     var applyCase = options.keepCase ? function(name) { return name; } : camelCase;
@@ -243,6 +248,10 @@ function parse(source, root, options) {
         skip("=");
         syntax = readString();
         isProto3 = syntax === "proto3";
+
+        if (!sourceContainsProto3) {
+            sourceContainsProto3 = isProto3;
+        }
 
         /* istanbul ignore if */
         if (!isProto3 && syntax !== "proto2")
@@ -729,6 +738,7 @@ function parse(source, root, options) {
     }
 
     parse.filename = null;
+    root.containsProto3 = sourceContainsProto3;
     return {
         "package"     : pkg,
         "imports"     : imports,

--- a/src/root.js
+++ b/src/root.js
@@ -34,6 +34,12 @@ function Root(options) {
      * @type {string[]}
      */
     this.files = [];
+
+    /**
+     * If any sources which built this Root used protobuf 3 syntax
+     * @type {boolean}
+     */
+    this.containsProto3 = false;
 }
 
 /**


### PR DESCRIPTION
This update correctly handles proto3 default value typings

Changes:

1. All primitive types (and enums) can't be null as they are given default values in proto3. Only messages can be null
2. Messages default to being "null" in the typings instead of "undefined"