### PR TITLE
Improved fromObject wrapper for google.protobuf.Any.

### DIFF
--- a/src/wrappers.js
+++ b/src/wrappers.js
@@ -44,8 +44,13 @@ wrappers[".google.protobuf.Any"] = {
         if (object && object["@type"]) {
             var type = this.lookup(object["@type"]);
             /* istanbul ignore else */
-            if (type)
-                return type.fromObject(object);
+            if (type) {
+                var obj = this.create({
+                    type_url: object["@type"],
+                    value: type.encode(object).finish()
+                });
+                return obj;
+            }
         }
 
         return this.fromObject(object);

--- a/tests/comp_google_protobuf_any.js
+++ b/tests/comp_google_protobuf_any.js
@@ -50,11 +50,8 @@ tape.test("google.protobuf.Any", function(test) {
             bar: "a"
         }
     });
-    test.ok(foo.foo instanceof Bar.ctor, "should unwrap wrapped Bar in fromObject");
-    test.same(foo.foo, { bar: "a" }, "should unwrap wrapper Bar in fromObject properly");
-
-    obj = Foo.toObject(foo);
-    test.same(obj.foo, { "@type": ".Bar", bar: "a" }, "should wrap Bar in toObject properly");
+    test.ok(foo.foo instanceof Any.ctor, "should convert to Any in fromObject");
+    test.same(foo.foo, { type_url: ".Bar", value: [10, 1, 97] }, "should have correct Any object when converted with fromObject");
 
     test.end();
 });


### PR DESCRIPTION
Now fromObject() can read back objects created with toObject()
containing google.protobuf.Any messages.

See issue #764.