### PR TITLE
Don't ship tests to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -8,5 +8,6 @@ docs/
 coverage/
 sandbox/
 examples/
+tests/
 pbjs.png
 pbjs.svg


### PR DESCRIPTION
Currently, when I `npm install protobufjs` I get `node_modules/protobufjs/tests` with about 1.6Mb worth of files.