### PR TITLE
Fix Reader argument conversion in static module

### DIFF
--- a/cli/targets/static.js
+++ b/cli/targets/static.js
@@ -505,7 +505,7 @@ function buildType(ref, type) {
             ++indent;
                 push("if (!(reader instanceof $Reader))");
                 ++indent;
-                    push("reader = $Reader(reader);");
+                    push("reader = new $Reader(reader);");
                 --indent;
                 push("return this.decode(reader, reader.uint32());");
             --indent;


### PR DESCRIPTION
Since the proposed change in #794 worked, I adapted the generator.
After compiling my `.proto` with the modified version, I did not need to manually create a `Reader` anymore, as originally intended.