### PR TITLE
Use protobuf/minimal when pbjs target is static-module

### DIFF
--- a/cli/pbjs.js
+++ b/cli/pbjs.js
@@ -33,7 +33,7 @@ exports.main = function main(args, callback) {
             "force-long": "strict-long",
             "force-message": "strict-message"
         },
-        string: [ "target", "out", "path", "wrap", "root", "lint" ],
+        string: [ "target", "out", "path", "wrap", "dependency", "root", "lint" ],
         boolean: [ "create", "encode", "decode", "verify", "convert", "delimited", "beautify", "comments", "es6", "sparse", "keep-case", "force-long", "force-number", "force-enum-string", "force-message" ],
         default: {
             target: "json",
@@ -100,6 +100,8 @@ exports.main = function main(args, callback) {
                 "                   amd       AMD wrapper",
                 "                   es6       ES6 wrapper (implies --es6)",
                 "                   closure   Just a closure adding to protobuf.roots (see -r)",
+                "",
+                "  --dependency     Specifies which version of protobuf to require. Accepts any valid module id",
                 "",
                 "  -r, --root       Specifies an alternative protobuf.roots name.",
                 "",

--- a/cli/targets/json-module.js
+++ b/cli/targets/json-module.js
@@ -3,6 +3,8 @@ module.exports = json_module;
 
 var util = require("../util");
 
+var protobuf = require("../..");
+
 json_module.description = "JSON representation as a module";
 
 function json_module(root, options, callback) {
@@ -17,7 +19,7 @@ function json_module(root, options, callback) {
         }
         var json = util.jsonSafeProp(JSON.stringify(root.nested, null, 2).trim());
         output.push(".addJSON(" + json + ");");
-        output = util.wrap(output.join(""), options);
+        output = util.wrap(output.join(""), protobuf.util.merge({ dependency: "protobufjs/minimal" }, options));
         process.nextTick(function() {
             callback(null, output);
         });

--- a/cli/wrappers/amd.js
+++ b/cli/wrappers/amd.js
@@ -1,4 +1,4 @@
-define(["protobuf"], function($protobuf) {
+define([$DEPENDENCY], function($protobuf) {
     "use strict";
 
     $OUTPUT;

--- a/cli/wrappers/default.js
+++ b/cli/wrappers/default.js
@@ -1,7 +1,7 @@
 (function(global, factory) { /* global define, require, module */
 
     /* AMD */ if (typeof define === 'function' && define.amd)
-        define(["protobuf"], factory);
+        define([$DEPENDENCY], factory);
 
     /* CommonJS */ else if (typeof require === 'function' && typeof module === 'object' && module && module.exports)
         module.exports = factory(require($DEPENDENCY));

--- a/cli/wrappers/es6.js
+++ b/cli/wrappers/es6.js
@@ -1,4 +1,4 @@
-import * as $protobuf from "protobufjs";
+import * as $protobuf from $DEPENDENCY;
 
 $OUTPUT;
 


### PR DESCRIPTION
This should fix #798 

Change affects AMD wrapper too, to be consistent.

Some modifications to AMD loader configs may be required, i.e. `protobufjs/minimal` should be mapped to correct file. Other option is to pass `dependency` argument to pbts and override default module name.