### PR TITLE
fixed 'error' is not defined linter warning when using static/static-module and es6

### DIFF
--- a/src/verifier.js
+++ b/src/verifier.js
@@ -31,10 +31,11 @@ function genVerifyValue(gen, field, fieldIndex, ref) {
             ("}");
         } else {
             gen
-            ((gen.hasErrorVar ? "" : "var ") + "e=types[%i].verify(%s);", fieldIndex, ref)
-            ("if(e)")
-                ("return%j+e", field.name + ".");
-            gen.hasErrorVar = true;
+            ("{")
+                ("var e=types[%i].verify(%s);", fieldIndex, ref)
+                ("if(e)")
+                    ("return%j+e", field.name + ".")
+            ("}");
         }
     } else {
         switch (field.type) {


### PR DESCRIPTION
I have found a little problem while using protobuf.js with react.js
 
I used the following proto file:
```
syntax = "proto3";

package api;

message Ping {
  string data = 1;
};

message Pong {
  string data = 1;
};

message Message {
  oneof message {
    Ping msg_ping = 1;
    Pong msg_pong = 2;
  };
}; 
```

with this compiler arguments:
`pbjs -t static-module -p src/api/ -o gen/api.js src/api/messages.proto`

Without the patch, the generated file contains this section:
```
Message.verify = function verify(message) {
    if (typeof message !== "object" || message === null)
        return "object expected";
    let properties = {};
    if (message.msgPing != null && message.hasOwnProperty("msgPing")) {
        properties.message = 1;
        let error = $root.api.Ping.verify(message.msgPing);
        if (error)
            return "msgPing." + error;
    }
    if (message.msgPong != null && message.hasOwnProperty("msgPong")) {
        if (properties.message === 1)
            return "message: multiple values";
        properties.message = 1;
        error = $root.api.Pong.verify(message.msgPong);
        if (error)
            return "msgPong." + error;
    }
    return null;
};
```

The problem is, that second error has no 'let' keyword before it. That generates a build error when I require(...) the generated file.
With the patch it looks like this:

```
Message.verify = function verify(message) {
    if (typeof message !== "object" || message === null)
        return "object expected";
    let properties = {};
    if (message.msgPing != null && message.hasOwnProperty("msgPing")) {
        properties.message = 1;
        {
            let error = $root.api.Ping.verify(message.msgPing);
            if (error)
                return "msgPing." + error;
        }
    }
    if (message.msgPong != null && message.hasOwnProperty("msgPong")) {
        if (properties.message === 1)
            return "message: multiple values";
        properties.message = 1;
        {
            let error = $root.api.Pong.verify(message.msgPong);
            if (error)
                return "msgPong." + error;
        }
    }
    return null;
};
```