### PR TITLE
buffer: using allocUnsafeSlow instead of allocUnsafe

### DIFF
--- a/src/util/minimal.js
+++ b/src/util/minimal.js
@@ -397,7 +397,7 @@ util._configure = function() {
         function Buffer_from(value, encoding) {
             return new Buffer(value, encoding);
         };
-    util._Buffer_allocUnsafe = Buffer.allocUnsafe ||
+    util._Buffer_allocUnsafe = Buffer.allocUnsafeSlow ||
         /* istanbul ignore next */
         function Buffer_allocUnsafe(size) {
             return new Buffer(size);


### PR DESCRIPTION
Take the following example to reproduce the problem:

```js
const buf = proto.encode(text).finish();
console.log(buf.length);  // 10/20/30 or other values, the real length of `text`
console.log(buf.buffer.byteLength); // 8192
```

The background of this example is to use the `ArrayBuffer` instance, `.buffer`. And `Buffer.allocUnsafeSlow()` could fix the problem :)