### PR TITLE
Fixed dependency for json-module to use "light".

### DIFF
--- a/cli/targets/json-module.js
+++ b/cli/targets/json-module.js
@@ -19,7 +19,7 @@ function json_module(root, options, callback) {
         }
         var json = util.jsonSafeProp(JSON.stringify(root.nested, null, 2).trim());
         output.push(".addJSON(" + json + ");");
-        output = util.wrap(output.join(""), protobuf.util.merge({ dependency: "protobufjs/minimal" }, options));
+        output = util.wrap(output.join(""), protobuf.util.merge({ dependency: "protobufjs/light" }, options));
         process.nextTick(function() {
             callback(null, output);
         });


### PR DESCRIPTION
"minimal" doesn't include `Root`, as mentioned in #828 and #856. Probably caused by #813.