### PR TITLE
Fixed: prevent codegen'ing a function with an invalid name.

### DIFF
--- a/lib/codegen/index.js
+++ b/lib/codegen/index.js
@@ -1,6 +1,28 @@
 "use strict";
 module.exports = codegen;
 
+var makeValidFunctionName = function() {
+    var memoized = {};
+
+    return function makeValidFunctionName(name) {
+        if ((name in memoized) && memoized[name]) {
+            return memoized[name];
+        }
+
+        try {
+            Function("return function " + name + "(){};");
+            memoized[name] = name;
+        } catch (err) {
+            if (/^[a-z]+$/i.test(name)) {
+                memoized[name] = makeValidFunctionName(name + "_");
+            } else {
+                memoized[name] = makeValidFunctionName(name.replace(/[^a-z]+/ig, '_'));
+            }
+        }
+        return memoized[name];
+    };
+}();
+
 /**
  * Begins generating a function.
  * @memberof util
@@ -15,6 +37,8 @@ function codegen(functionParams, functionName) {
         functionName = functionParams;
         functionParams = undefined;
     }
+
+    functionName = makeValidFunctionName(functionName);
 
     var body = [];
 

--- a/lib/codegen/tests/index.js
+++ b/lib/codegen/tests/index.js
@@ -1,6 +1,6 @@
 var codegen = require("..");
 
-// new require("benchmark").Suite().add("add", function() {
+// new require("benchmark").Suite().add("add + delete", function() {
 
 var add = codegen(["a", "b"], "add")
   ("// awesome comment")
@@ -9,5 +9,23 @@ var add = codegen(["a", "b"], "add")
 
 if (add(1, 2) !== 3)
   throw Error("failed");
+
+var object = { a: 1, b: 2 };
+var delete_ = codegen(["object", "property"], "delete3")
+  ("delete object[property];")
+  ();
+
+delete_(object, 'a');
+
+if ("a" in object)
+  throw Error("expected 'a' property to be deleted but was not");
+
+if (!delete_.name.includes('delete'))
+  throw Error("expected function name to contain 'delete': " + delete_.name);
+
+delete_(object, 'b');
+
+if (JSON.stringify(object) !== '{}')
+  throw Error("unexpected JSON: " + JSON.stringify(object));
 
 // }).on("cycle", function(event) { process.stdout.write(String(event.target) + "\n"); }).run();


### PR DESCRIPTION
This can happen when, for example, an RPC method name is the uppercase of a keyword like "Delete". I tried to retain the performance of the original, but since the test just uses the same names over and over again and they're memoized it's not a super representative set of test data to really understand how the performance changed.