### PR TITLE
Annotate virtual oneof fields as string literal unions

### DIFF
--- a/cli/targets/static.js
+++ b/cli/targets/static.js
@@ -435,7 +435,7 @@ function buildType(ref, type) {
         push("");
         pushComment([
             oneof.comment || type.name + " " + oneof.name + ".",
-            "@member {string|undefined} " + escapeName(oneof.name),
+            "@member {" + oneof.oneof.map(JSON.stringify).join("|") + "|undefined} " + escapeName(oneof.name),
             "@memberof " + exportName(type),
             "@instance"
         ]);


### PR DESCRIPTION
This PR changes the type definition of virtual oneof fields from a `string` type to a more restrictive string literal union of the possible field values.

Ex:
```protobuf
oneof data {
  TypeA typea = 1;
  TypeB typeb = 2;
}
```
is now annotated as 
```typescript
public data?: ("typea"|"typeb");
```

instead of 
```typescript
public data?: string;
```

This change prevents string comparison typos in TypeScript code. It also enables the use of exhaustive case-switch statements when handling `oneof` messages in application codebases.

Ex:
```typescript
function assertUnreachable(x: never): never {
    throw new Error();
}

switch(message.data) {
  case 'typea':
    break;
  case 'typeb':
    break;
  default:
    assertUnreachable(message.data); 
}
```
