### PR TITLE
CLI: Annotating class definitions with @implements

### DIFF
--- a/cli/targets/static.js
+++ b/cli/targets/static.js
@@ -380,6 +380,7 @@ function buildType(ref, type) {
         "Constructs a new " + type.name + ".",
         type.parent instanceof protobuf.Root ? "@exports " + escapeName(type.name) : "@memberof " + exportName(type.parent),
         "@classdesc " + (type.comment || "Represents " + aOrAn(type.name) + "."),
+        config.comments ? "@implements " + escapeName("I" + type.name) : null,
         "@constructor",
         "@param {" + exportName(type, true) + "=} [" + (config.beautify ? "properties" : "p") + "] Properties to set"
     ]);


### PR DESCRIPTION
All classes now are annotated as implementing their respective interfaces. 

Ex. when generating the TypeScript .d.ts,

```typescript
export class Message {}
```
now becomes

```typescript
export class Message implements IMessage {}
```

This PR, along with https://github.com/dcodeIO/protobuf.js/commit/ed7e2e71f5cde27c4128f4f2e3f4782cc51fbec7, should help solve #844.