### PR TITLE
proto3: skip defaults

### DIFF
--- a/cli/targets/proto.js
+++ b/cli/targets/proto.js
@@ -238,6 +238,8 @@ function buildFieldOptions(field) {
                     return;
                 break;
             case "default":
+                if (syntax === 3)
+                    return;
                 // skip default (resolved) default values
                 if (field.long && !util.longNeq(field.defaultValue, types.defaults[field.type]) || !field.long && field.defaultValue === types.defaults[field.type])
                     return;


### PR DESCRIPTION
Defaults are not supported in proto3, and therefore should
not be appended to a `.proto` file when using `-t proto3`
flag for `pbjs`.