### PR TITLE
CLI: Remove exclude and include patterns from jsdoc config

### DIFF
--- a/cli/lib/tsd-jsdoc.json
+++ b/cli/lib/tsd-jsdoc.json
@@ -2,11 +2,6 @@
     "tags": {
         "allowUnknownTags": false
     },
-    "source": {
-        "exclude": [],
-        "includePattern": ".+\\.js(doc)?$",
-        "excludePattern": "(^|\\/|\\\\)_"
-    },
     "plugins": [
         "./tsd-jsdoc/plugin"
     ],


### PR DESCRIPTION
It is not necessary to provide include and exclude patterns in jsdoc config because pbts is setting files explicitly when pbts binary is called.

The excludePattern breaks everything when a path to project contains underscore.
E.g.:
```sh
$ pwd
/Users/nikita/Develop/_demo/demo-project
$ ./node_modules/protobufjs/bin/pbts ./bin/proto/all.js
import * as $protobuf from "protobufjs";

There are no input files to process
```