### PR TITLE
Preserve comments when serializing/deserializing with toJSON and fromJSON

### DIFF
--- a/src/field.js
+++ b/src/field.js
@@ -35,7 +35,7 @@ var ruleRe = /^required|optional|repeated$/;
  * @throws {TypeError} If arguments are invalid
  */
 Field.fromJSON = function fromJSON(name, json) {
-    return new Field(name, json.id, json.type, json.rule, json.extend, json.options);
+    return new Field(name, json.id, json.type, json.rule, json.extend, json.options, json.comment);
 };
 
 /**
@@ -50,8 +50,9 @@ Field.fromJSON = function fromJSON(name, json) {
  * @param {string|Object.<string,*>} [rule="optional"] Field rule
  * @param {string|Object.<string,*>} [extend] Extended type if different from parent
  * @param {Object.<string,*>} [options] Declared options
+ * @param {string} comment Comment associated with this field
  */
-function Field(name, id, type, rule, extend, options) {
+function Field(name, id, type, rule, extend, options, comment) {
 
     if (util.isObject(rule)) {
         options = rule;
@@ -183,6 +184,12 @@ function Field(name, id, type, rule, extend, options) {
      * @private
      */
     this._packed = null;
+
+    /**
+     * Comment for this field.
+     * @type {string|undefined}
+     */
+    this.comment = comment;
 }
 
 /**
@@ -235,7 +242,8 @@ Field.prototype.toJSON = function toJSON() {
         "type"    , this.type,
         "id"      , this.id,
         "extend"  , this.extend,
-        "options" , this.options
+        "options" , this.options,
+        "comment" , this.comment
     ]);
 };
 

--- a/src/method.js
+++ b/src/method.js
@@ -19,8 +19,9 @@ var util = require("./util");
  * @param {boolean|Object.<string,*>} [requestStream] Whether the request is streamed
  * @param {boolean|Object.<string,*>} [responseStream] Whether the response is streamed
  * @param {Object.<string,*>} [options] Declared options
+ * @param {string} comment The comment for this method
  */
-function Method(name, type, requestType, responseType, requestStream, responseStream, options) {
+function Method(name, type, requestType, responseType, requestStream, responseStream, options, comment) {
 
     /* istanbul ignore next */
     if (util.isObject(requestStream)) {
@@ -86,6 +87,12 @@ function Method(name, type, requestType, responseType, requestStream, responseSt
      * @type {Type|null}
      */
     this.resolvedResponseType = null;
+
+    /**
+     * Comment for this method
+     * @type {string|undefined}
+     */
+    this.comment = comment;
 }
 
 /**
@@ -107,7 +114,7 @@ function Method(name, type, requestType, responseType, requestStream, responseSt
  * @throws {TypeError} If arguments are invalid
  */
 Method.fromJSON = function fromJSON(name, json) {
-    return new Method(name, json.type, json.requestType, json.responseType, json.requestStream, json.responseStream, json.options);
+    return new Method(name, json.type, json.requestType, json.responseType, json.requestStream, json.responseStream, json.options, json.comment);
 };
 
 /**
@@ -121,7 +128,8 @@ Method.prototype.toJSON = function toJSON() {
         "requestStream"  , this.requestStream,
         "responseType"   , this.responseType,
         "responseStream" , this.responseStream,
-        "options"        , this.options
+        "options"        , this.options,
+        "comment"        , this.comment
     ]);
 };
 

--- a/src/service.js
+++ b/src/service.js
@@ -57,6 +57,7 @@ Service.fromJSON = function fromJSON(name, json) {
             service.add(Method.fromJSON(names[i], json.methods[names[i]]));
     if (json.nested)
         service.addJSON(json.nested);
+    service.comment = json.comment;
     return service;
 };
 
@@ -69,7 +70,8 @@ Service.prototype.toJSON = function toJSON() {
     return util.toObject([
         "options" , inherited && inherited.options || undefined,
         "methods" , Namespace.arrayToJSON(this.methodsArray) || /* istanbul ignore next */ {},
-        "nested"  , inherited && inherited.nested || undefined
+        "nested"  , inherited && inherited.nested || undefined,
+        "comment" , this.comment
     ]);
 };
 

--- a/src/type.js
+++ b/src/type.js
@@ -270,6 +270,8 @@ Type.fromJSON = function fromJSON(name, json) {
         type.reserved = json.reserved;
     if (json.group)
         type.group = true;
+    if (json.comment)
+        type.comment = json.comment;
     return type;
 };
 
@@ -286,7 +288,8 @@ Type.prototype.toJSON = function toJSON() {
         "extensions" , this.extensions && this.extensions.length ? this.extensions : undefined,
         "reserved"   , this.reserved && this.reserved.length ? this.reserved : undefined,
         "group"      , this.group || undefined,
-        "nested"     , inherited && inherited.nested || undefined
+        "nested"     , inherited && inherited.nested || undefined,
+        "comment"    , this.comment || undefined
     ]);
 };
 

--- a/tests/comment_serialization.js
+++ b/tests/comment_serialization.js
@@ -1,0 +1,28 @@
+var tape = require("tape");
+
+var protobuf = require("..");
+
+tape.test("preserve comments through de/serialization", function(test) {
+    test.plan(6);
+    protobuf.load("tests/data/comment_serialization.proto", function(err, root) {
+        if (err) {
+            throw test.fail(err.message);
+        }
+
+        var copy = protobuf.Root.fromJSON(root.toJSON());
+        test.equal(root.lookup("TestMessage").comment, copy.lookup("TestMessage").comment);
+        test.equal(root.lookup("TestMessage.testField").comment, copy.lookup("TestMessage.testField").comment);
+
+        var rootService = root.lookupService("TestService");
+        var copyService = copy.lookupService("TestService");
+        test.equal(rootService.comment, copyService.comment);
+        test.equal(rootService.methods["testMethod"].comment, copyService.methods["testMethod"].comment);
+
+        var rootEnum = root.lookup("TestEnum");
+        var copyEnum = root.lookup("TestEnum");
+        test.equal(rootEnum.comment, copyEnum.comment);
+        test.equal(rootEnum.comments.VALUE, copyEnum.comments.VALUE);
+
+        test.end();
+    });
+});

--- a/tests/data/comment_serialization.proto
+++ b/tests/data/comment_serialization.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+/// message comment
+message TestMessage {
+    /// field comment
+    string testField = 1;
+}
+
+/// service comment
+service TestService {
+  /// method comment
+  rpc testMethod(TestMessage) returns (TestMessage) {}
+}
+
+/// enum comment
+enum TestEnum {
+    /// enum value comment
+    VALUE = 1;
+}


### PR DESCRIPTION
This will unblock scenarios where we want to consume the comments even after serializing a root with toJSON.