### PR TITLE
964 enum circular dep react native

### DIFF
--- a/src/enum.js
+++ b/src/enum.js
@@ -5,7 +5,7 @@ module.exports = Enum;
 var ReflectionObject = require("./object");
 ((Enum.prototype = Object.create(ReflectionObject.prototype)).constructor = Enum).className = "Enum";
 
-var Namespace = require("./namespace"),
+var getNamespace = ()=> require("./namespace"),
     util = require("./util");
 
 /**
@@ -168,7 +168,7 @@ Enum.prototype.remove = function remove(name) {
  * @returns {boolean} `true` if reserved, otherwise `false`
  */
 Enum.prototype.isReservedId = function isReservedId(id) {
-    return Namespace.isReservedId(this.reserved, id);
+    return getNamespace().isReservedId(this.reserved, id);
 };
 
 /**
@@ -177,5 +177,5 @@ Enum.prototype.isReservedId = function isReservedId(id) {
  * @returns {boolean} `true` if reserved, otherwise `false`
  */
 Enum.prototype.isReservedName = function isReservedName(name) {
-    return Namespace.isReservedName(this.reserved, name);
+    return getNamespace().isReservedName(this.reserved, name);
 };

--- a/src/enum.js
+++ b/src/enum.js
@@ -5,7 +5,7 @@ module.exports = Enum;
 var ReflectionObject = require("./object");
 ((Enum.prototype = Object.create(ReflectionObject.prototype)).constructor = Enum).className = "Enum";
 
-var getNamespace = ()=> require("./namespace"),
+var getNamespace = function () { return require("./namespace") },
     util = require("./util");
 
 /**


### PR DESCRIPTION
React native default setup is unable to handle the circular dependency. Delaying the use solves this (7 char change, but changed to legacy function style to match code style).

See https://github.com/dcodeIO/protobuf.js/issues/964.