### PR TITLE
Ignore optional commas in aggregate options

### DIFF
--- a/src/parse.js
+++ b/src/parse.js
@@ -567,6 +567,7 @@ function parse(source, root, options) {
                     else
                         setOption(parent, name + "." + token, readValue(true));
                 }
+                skip(",", true);
             } while (!skip("}", true));
         } else
             setOption(parent, name, readValue(true));

--- a/tests/comp_options-textformat.js
+++ b/tests/comp_options-textformat.js
@@ -14,6 +14,7 @@ extend google.protobuf.FieldOptions {\
 message Test {\
   string value = 1 [(my_options) = { a: \"foo\" b: \"bar\" }];\
   string value2 = 2 [(my_options) = { a: \"foo\" b { c: \"bar\" } }];\
+  string value3 = 3 [(my_options) = { a: \"foo\", b: \"bar\" }];\
 }";
 
 tape.test("options in textformat", function(test) {
@@ -21,5 +22,6 @@ tape.test("options in textformat", function(test) {
     var Test = root.lookup("Test");
     test.same(Test.fields.value.options, { "(my_options).a": "foo", "(my_options).b": "bar" }, "should parse correctly");
     test.same(Test.fields.value2.options, { "(my_options).a": "foo", "(my_options).b.c": "bar" }, "should parse correctly when nested");
+    test.same(Test.fields.value3.options, { "(my_options).a": "foo", "(my_options).b": "bar" }, "should parse correctly when comma-separated");
     test.end();
 });


### PR DESCRIPTION
More information on the "Aggregate Syntax" here:
https://github.com/google/protobuf/issues/1148

These are accepted by the proto compiler but rarely used - I found an
example in the
[Cloud Endpoints docs](https://cloud.google.com/endpoints/docs/grpc-service-config/reference/rpc/google.api#google.api.HttpRule.FIELDS.string.google.api.HttpRule.rest_method_name).

Fixes #383.