### PR TITLE
Support Service in Root.fromDescriptor

### DIFF
--- a/ext/descriptor/index.js
+++ b/ext/descriptor/index.js
@@ -96,6 +96,9 @@ Root.fromDescriptor = function fromDescriptor(descriptor) {
             if (fileDescriptor.extension)
                 for (i = 0; i < fileDescriptor.extension.length; ++i)
                     filePackage.add(Field.fromDescriptor(fileDescriptor.extension[i]));
+            if (fileDescriptor.service)
+                for (i = 0; i < fileDescriptor.service.length; ++i)
+                    filePackage.add(Service.fromDescriptor(fileDescriptor.service[i]));
             var opts = fromDescriptorOptions(fileDescriptor.options, exports.FileOptions);
             if (opts) {
                 var ks = Object.keys(opts);


### PR DESCRIPTION
I'm working on a server that can dynamically discover and map gRPC services to HTTP using [ServerReflection](https://github.com/grpc/grpc-go/blob/master/reflection/grpc_reflection_v1alpha/reflection.proto). The ReflectionObject parsed from the descriptor returned by the reflection service is missing the service stubs.