### PR TITLE
Added GRPC Metadata supports for pbts.

### DIFF
--- a/cli/pbts.js
+++ b/cli/pbts.js
@@ -141,11 +141,22 @@ exports.main = function(args, callback) {
                     "export as namespace " + argv.global + ";",
                     ""
                 );
-            if (!argv.main)
+            if (!argv.main) {
+
                 output.push(
-                    "import * as $protobuf from \"protobufjs\";",
+                    "import * as $protobuf from \"protobufjs\";"
+                );
+
+                if (out.find(x => x.indexOf("gRPC.Metadata") > -1)) {
+
+                    output.push(
+                        "import * as gRPC from \"grpc\";",
+                    );
+                }
+                output.push(
                     ""
                 );
+            }
             output = output.join("\n") + "\n" + out.join("");
 
             try {


### PR DESCRIPTION
Current edition of pbts can not generate the parameter `metadata: GRPC.Metadata` for GRPC client methods, for example:

```protobuf
service SampleV1 {

    rpc SayHello(SampleHelloRequest) returns (SampleHelloReply) {}
}
```

the method `SayHello` should be generated as

```ts

/**
 * Calls SayHello.
 * @param request SampleHelloRequest message or plain object
 * @param callback Node-style callback called with the error, if any, and SampleHelloReply
 */
public sayHello(request: reolink.services.ISampleHelloRequest, callback: reolink.services.SampleV1.SayHelloCallback): void;

/**
 * Calls SayHello.
 * @param request SampleHelloRequest message or plain object
 * @param metadata GRPC request metadata
 * @param callback Node-style callback called with the error, if any, and SampleHelloReply
 */
public sayHello(request: reolink.services.ISampleHelloRequest, metadata: gRPC.Metadata, callback: reolink.services.SampleV1.SayHelloCallback): void;

/**
 * Calls SayHello.
 * @param request SampleHelloRequest message or plain object
 * @returns Promise
 */
public sayHello(request: reolink.services.ISampleHelloRequest): Promise<reolink.services.SampleHelloReply>;

/**
 * Calls SayHello.
 * @param request SampleHelloRequest message or plain object
 * @param metadata GRPC request metadata
 * @returns Promise
 */
public sayHello(request: reolink.services.ISampleHelloRequest, metadata: gRPC.Metadata): Promise<reolink.services.SampleHelloReply>;
```

However, the current version of pbts doesn't make it.

This patch should fixed it.