### PR TITLE
remove return type requirement of pbjs callback

### DIFF
--- a/cli/pbjs.d.ts
+++ b/cli/pbjs.d.ts
@@ -1,4 +1,4 @@
-type pbjsCallback = (err: Error|null, output?: string) => {};
+type pbjsCallback = (err: Error|null, output?: string) => void;
 
 /**
  * Runs pbjs programmatically.

--- a/cli/pbjs.d.ts
+++ b/cli/pbjs.d.ts
@@ -1,4 +1,4 @@
-type pbjsCallback = (err: Error|null, output?: string) => number|undefined;
+type pbjsCallback = (err: Error|null, output?: string) => void;
 
 /**
  * Runs pbjs programmatically.

--- a/cli/pbjs.d.ts
+++ b/cli/pbjs.d.ts
@@ -1,4 +1,4 @@
-type pbjsCallback = (err: Error|null, output?: string) => void;
+type pbjsCallback = (err: Error|null, output?: string) => number|undefined;
 
 /**
  * Runs pbjs programmatically.


### PR DESCRIPTION
The callback function of pbjs main should not enforce a return value.