### PR TITLE
Use same node when shelling out to jsdoc

### DIFF
--- a/cli/pbts.js
+++ b/cli/pbts.js
@@ -98,7 +98,7 @@ exports.main = function(args, callback) {
         // There is no proper API for jsdoc, so this executes the CLI and pipes the output
         var basedir = path.join(__dirname, ".");
         var moduleName = argv.name || "null";
-        var cmd = "node \"" + require.resolve("jsdoc/jsdoc.js") + "\" -c \"" + path.join(basedir, "lib", "tsd-jsdoc.json") + "\" -q \"module=" + encodeURIComponent(moduleName) + "&comments=" + Boolean(argv.comments) + "\" " + files.map(function(file) { return "\"" + file + "\""; }).join(" ");
+        var cmd = process.execPath + " \"" + require.resolve("jsdoc/jsdoc.js") + "\" -c \"" + path.join(basedir, "lib", "tsd-jsdoc.json") + "\" -q \"module=" + encodeURIComponent(moduleName) + "&comments=" + Boolean(argv.comments) + "\" " + files.map(function(file) { return "\"" + file + "\""; }).join(" ");
         var child = child_process.exec(cmd, {
             cwd: process.cwd(),
             argv0: "node",


### PR DESCRIPTION
Right now we assume that the node in the process.env['PATH'] will be the right one. If the user uses a certain version of node to invoke pbts (or doesn't have node on their PATH) then this does the wrong thing. We should spawn another copy of the same node binary that's already running.