### PR TITLE
Allow abstract methods

### DIFF
--- a/cli/lib/tsd-jsdoc/publish.js
+++ b/cli/lib/tsd-jsdoc/publish.js
@@ -645,7 +645,9 @@ function handleFunction(element, parent, isConstructor) {
         insideClass = isClassLike(parent);
         if (insideClass) {
             write(element.access || "public", " ");
-            if (element.scope === "static")
+            if (element.virtual)
+                write("abstract ");
+            else if (element.scope === "static")
                 write("static ");
         } else
             write("function ");

--- a/cli/lib/tsd-jsdoc/publish.js
+++ b/cli/lib/tsd-jsdoc/publish.js
@@ -645,10 +645,10 @@ function handleFunction(element, parent, isConstructor) {
         insideClass = isClassLike(parent);
         if (insideClass) {
             write(element.access || "public", " ");
-            if (element.virtual)
-                write("abstract ");
-            else if (element.scope === "static")
+            if (element.scope === "static")
                 write("static ");
+            else if (element.virtual)
+                write("abstract ");
         } else
             write("function ");
         write(element.name);


### PR DESCRIPTION
The tsd-jsdoc currently doesn't allow you to create typings for abstract methods.

This means you cannot create typed target templates to inherit from, this PR fixes that.