### PR TITLE
Custom pbts type imports

### DIFF
--- a/cli/lib/tsd-jsdoc/publish.js
+++ b/cli/lib/tsd-jsdoc/publish.js
@@ -645,7 +645,9 @@ function handleFunction(element, parent, isConstructor) {
         insideClass = isClassLike(parent);
         if (insideClass) {
             write(element.access || "public", " ");
-            if (element.scope === "static")
+            if (element.virtual)
+                write("abstract ");
+            else if (element.scope === "static")
                 write("static ");
         } else
             write("function ");

--- a/cli/lib/tsd-jsdoc/publish.js
+++ b/cli/lib/tsd-jsdoc/publish.js
@@ -645,10 +645,10 @@ function handleFunction(element, parent, isConstructor) {
         insideClass = isClassLike(parent);
         if (insideClass) {
             write(element.access || "public", " ");
-            if (element.virtual)
-                write("abstract ");
-            else if (element.scope === "static")
+            if (element.scope === "static")
                 write("static ");
+            else if (element.virtual)
+                write("abstract ");
         } else
             write("function ");
         write(element.name);

--- a/cli/pbts.js
+++ b/cli/pbts.js
@@ -24,9 +24,10 @@ exports.main = function(args, callback) {
             name: "n",
             out : "o",
             main: "m",
-            global: "g"
+            global: "g",
+            import: "i"
         },
-        string: [ "name", "out", "global" ],
+        string: [ "name", "out", "global", "import" ],
         boolean: [ "comments", "main" ],
         default: {
             comments: true,
@@ -48,6 +49,8 @@ exports.main = function(args, callback) {
                 "  -o, --out       Saves to a file instead of writing to stdout.",
                 "",
                 "  -g, --global    Name of the global object in browser environments, if any.",
+                "",
+                "  -i, --import    Comma delimited list of imports. Local names will equal camelCase of the basename.",
                 "",
                 "  --no-comments   Does not output any JSDoc comments.",
                 "",
@@ -134,6 +137,13 @@ exports.main = function(args, callback) {
             return undefined;
         });
 
+        function getImportName(importItem) {
+            var result = path.basename(importItem, ".js")
+            return result.replace(/([-_~.+]\w)/g, match => {
+                return match[1].toUpperCase();
+            });
+        }
+
         function finish() {
             var output = [];
             if (argv.global)
@@ -141,11 +151,25 @@ exports.main = function(args, callback) {
                     "export as namespace " + argv.global + ";",
                     ""
                 );
-            if (!argv.main)
-                output.push(
-                    "import * as $protobuf from \"protobufjs\";",
-                    ""
-                );
+
+            if (!argv.main) {
+                // Ensure we have a usable array of imports
+                var importArray = typeof argv.import === "string" ? argv.import.split(",") : argv.import || [];
+
+                // Build an object of imports and paths
+                var imports = {
+                    $protobuf: "protobufjs"
+                };
+                importArray.forEach(function(importItem) {
+                    imports[getImportName(importItem)] = importItem;
+                });
+
+                // Write out the imports
+                Object.keys(imports).forEach(function(key) {
+                    output.push("import * as " + key + " from \"" + imports[key] + "\";");
+                });
+            }
+
             output = output.join("\n") + "\n" + out.join("");
 
             try {


### PR DESCRIPTION
With reference to #1034, this is an example of how extra imports could be added to the generated types using the `pbts` cli tool.

It's far from an ideal solution, but works.