### PR TITLE
Fix package browser field descriptor

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "typescript"
   ],
   "main": "index.js",
-  "browser": "dist/protobuf.js",
   "types": "index.d.ts",
   "bin": {
     "pbjs": "bin/pbjs",

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
   ],
   "main": "index.js",
   "browser": {
-    "protobufjs": "./src/index.js",
-    "protobufjs-light": "./src/index-light.js",
-    "protobufjs-minimal": "./src/index-minimal.js"
+    "protobufjs": "./index.js",
+    "protobufjs/light": "./light.js",
+    "protobufjs/minimal": "./minimal.js"
   },
   "types": "index.d.ts",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -18,11 +18,7 @@
     "typescript"
   ],
   "main": "index.js",
-  "browser": {
-    "protobufjs": "./index.js",
-    "protobufjs/light": "./light.js",
-    "protobufjs/minimal": "./minimal.js"
-  },
+  "browser": "index.js",
   "types": "index.d.ts",
   "bin": {
     "pbjs": "bin/pbjs",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "typescript"
   ],
   "main": "index.js",
-  "browser": "index.js",
   "types": "index.d.ts",
   "bin": {
     "pbjs": "bin/pbjs",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,11 @@
     "typescript"
   ],
   "main": "index.js",
+  "browser": {
+    "protobufjs": "./src/index.js",
+    "protobufjs-light": "./src/index-light.js",
+    "protobufjs-minimal": "./src/index-minimal.js"
+  },
   "types": "index.d.ts",
   "bin": {
     "pbjs": "bin/pbjs",


### PR DESCRIPTION
The [package browser field descriptor](https://github.com/defunctzombie/package-browser-field-spec) expects an entry point, rather than the bundle file path.

This change specifies an entry point for the three different libraries.

Addresses issue https://github.com/dcodeIO/protobuf.js/issues/1045