### PR TITLE
Make Message<T> have a default type param

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -507,7 +507,7 @@ export interface IExtensionMapField extends IMapField {
 }
 
 /** Abstract runtime message. */
-export class Message<T extends object> {
+export class Message<T extends object = object> {
 
     /**
      * Constructs a new message instance.


### PR DESCRIPTION
For context: https://github.com/grpc/grpc-node/issues/425

The type definitions for PB 5/6 are not mutually compatible because of the `Message` class: one requires that the generic type parameter doesn't exist, while the other one require that it does. As a result, we cannot publish type definitions that are compatible with both.

This PR gives `Message<T>` a default value for `T` to work around that. This doesn't relate to any need other than what I described above, so if there is a better way to solve the problem, I would be open to implementing suggestions.