### PR TITLE
Message.toObject decode bytes to UTF8 String 

### DIFF
--- a/src/converter.js
+++ b/src/converter.js
@@ -179,7 +179,7 @@ function genValuePartial_toObject(gen, field, fieldIndex, prop) {
                 ("d%s=o.longs===String?util.Long.prototype.toString.call(m%s):o.longs===Number?new util.LongBits(m%s.low>>>0,m%s.high>>>0).toNumber(%s):m%s", prop, prop, prop, prop, isUnsigned ? "true": "", prop);
                 break;
             case "bytes": gen
-            ("d%s=o.bytes===String?util.base64.encode(m%s,0,m%s.length):o.bytes===Array?Array.prototype.slice.call(m%s):m%s", prop, prop, prop, prop, prop);
+            ("d%s=o.bytes===String?util.base64.encode(m%s,0,m%s.length):o.bytes===Array?Array.prototype.slice.call(m%s):o.bytes==='utf8'?m%s.toString('utf8'):m%s", prop, prop, prop, prop, prop, prop);
                 break;
             default: gen
             ("d%s=m%s", prop, prop);

--- a/tests/api_converters.js
+++ b/tests/api_converters.js
@@ -123,6 +123,7 @@ tape.test("converters", function(test) {
 
                 test.equal(Object.prototype.toString.call(Message.toObject(msg, { bytes: Array }).bytesVal), "[object Array]", "bytes to arrays");
                 test.equal(Message.toObject(msg, { bytes: String }).bytesVal, "MTEx", "bytes to base64 strings");
+                test.equal(Message.toObject(msg, { bytes: 'utf8' }).bytesVal, "111", "bytes to utf8 strings");
                 if (protobuf.util.isNode)
                     test.ok(Buffer.isBuffer(Message.toObject(msg, { bytes: Buffer }).bytesVal), "bytes to buffers");
 


### PR DESCRIPTION
 Using option `{ bytes: 'utf8' }` in `Message.toObject` will decode bytes to String (`Buffer.toString()`). Previos options are preserved.