### PR TITLE
wip: RPC server, client, bidirectional streaming

### DIFF
--- a/cli/targets/static.js
+++ b/cli/targets/static.js
@@ -626,8 +626,12 @@ function buildService(ref, service) {
     }
 
     service.methodsArray.forEach(function(method) {
-        if (method.responseStream) {
-            buildStreamingServiceMethod(service, method);
+        if (method.requestStream && method.responseStream) {
+            buildBidiStreamingMethod(service, method);
+        } else if (method.requestStream) {
+            buildClientStreamingMethod(service, method);
+        } else if (method.responseStream) {
+            buildServerStreamingMethod(service, method);
         } else {
             buildUnaryServiceMethod(service, method);
         }
@@ -677,33 +681,57 @@ function buildUnaryServiceMethod(service, method) {
     ]);
 }
 
-function buildStreamingServiceMethod(service, method) {
+function buildServerStreamingMethod(service, method) {
     method.resolve();
-    var lcName = protobuf.util.lcFirst(method.name),
-        cbName = escapeName(method.name + "Callback");
-    push("");
-    pushComment([
-        "Callback as used by {@link " + exportName(service) + "#" + escapeName(lcName) + "}.",
-        // This is a more specialized version of protobuf.rpc.ServiceCallback
-        "@memberof " + exportName(service),
-        "@typedef " + cbName,
-        "@type {function}",
-        "@param {Error|null} error Error, if any",
-        "@param {" + exportName(method.resolvedResponseType) + "} [response] " + method.resolvedResponseType.name
-    ]);
-    push("");
+    var lcName = protobuf.util.lcFirst(method.name);
     pushComment([
         method.comment || "Calls " + method.name + ".",
         "@function " + lcName,
         "@memberof " + exportName(service),
         "@instance",
         "@param {" + exportName(method.resolvedRequestType, !config.forceMessage) + "} request " + method.resolvedRequestType.name + " message or plain object",
-        "@returns {util.EventEmitter}",
+        "@returns {RPCServerStream<" + exportName(method.resolvedResponseType) + ">}",
         "@variation 1"
     ]);
     push("Object.defineProperty(" + escapeName(service.name) + ".prototype" + util.safeProp(lcName) + " = function " + escapeName(lcName) + "(request, callback) {");
         ++indent;
-        push("return this.rpcStreamingCall(" + escapeName(lcName) + ", $root." + exportName(method.resolvedRequestType) + ", $root." + exportName(method.resolvedResponseType) + ", request);");
+        push("return this.serverStreamCall(" + escapeName(lcName) + ", $root." + exportName(method.resolvedRequestType) + ", $root." + exportName(method.resolvedResponseType) + ", request);");
+        --indent;
+    push("}, \"name\", { value: " + JSON.stringify(method.name) + " });");
+}
+
+function buildClientStreamingMethod(service, method) {
+    method.resolve();
+    var lcName = protobuf.util.lcFirst(method.name);
+    pushComment([
+        method.comment || "Calls " + method.name + ".",
+        "@function " + lcName,
+        "@memberof " + exportName(service),
+        "@instance",
+        "@returns {RPCClientStream<" + exportName(method.resolvedRequestType) + ">}",
+        "@variation 1"
+    ]);
+    push("Object.defineProperty(" + escapeName(service.name) + ".prototype" + util.safeProp(lcName) + " = function " + escapeName(lcName) + "() {");
+        ++indent;
+        push("return this.clientStreamCall(" + escapeName(lcName) + ", $root." + exportName(method.resolvedRequestType) + ", $root." + exportName(method.resolvedResponseType) + ");");
+        --indent;
+    push("}, \"name\", { value: " + JSON.stringify(method.name) + " });");
+}
+
+function buildBidiStreamingMethod(service, method) {
+    method.resolve();
+    var lcName = protobuf.util.lcFirst(method.name);
+    pushComment([
+        method.comment || "Calls " + method.name + ".",
+        "@function " + lcName,
+        "@memberof " + exportName(service),
+        "@instance",
+        "@returns {RPCBidiStream<" + exportName(method.resolvedRequestType) + ", " + exportName(method.resolvedResponseType) + ">}",
+        "@variation 1"
+    ]);
+    push("Object.defineProperty(" + escapeName(service.name) + ".prototype" + util.safeProp(lcName) + " = function " + escapeName(lcName) + "() {");
+        ++indent;
+        push("return this.bidiStreamCall(" + escapeName(lcName) + ", $root." + exportName(method.resolvedRequestType) + ", $root." + exportName(method.resolvedResponseType) + ");");
         --indent;
     push("}, \"name\", { value: " + JSON.stringify(method.name) + " });");
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1305,14 +1305,13 @@ export namespace rpc {
 
     /** An RPC service as returned by {@link Service#create}. */
     class Service extends util.EventEmitter {
-
         /**
          * Constructs a new RPC service instance.
          * @param rpcImpl RPC implementation
          * @param [requestDelimited=false] Whether requests are length-delimited
          * @param [responseDelimited=false] Whether responses are length-delimited
          */
-        constructor(rpcImpl: RPCImpl, requestDelimited?: boolean, responseDelimited?: boolean);
+        constructor(rpcImpl: RPCImpl | RPCHandler, requestDelimited?: boolean, responseDelimited?: boolean);
 
         /** RPC implementation. Becomes `null` once the service is ended. */
         public rpcImpl: (RPCImpl|null);
@@ -1342,13 +1341,24 @@ export namespace rpc {
     }
 }
 
+type RPCUnaryCall = (method: (Method|rpc.ServiceMethod<Message<{}>, Message<{}>>), requestData: Uint8Array, callback: RPCImplCallback) => void;
+type RPCStreamingCall = (method: (Method|rpc.ServiceMethod<Message<{}>, Message<{}>>), requestData: Uint8Array, responseFn: (responseData: Uint8Array) => protobuf.Message): util.EventEmitter;
+
+/**
+ * RPCHandler allows to pass custom RPC implementation for unary and streaming calls
+ */
+export interface RPCHandler {
+    unaryCall: RPCUnaryCall;
+    streamingCall: RPCStreamingCall;
+}
+
 /**
  * RPC implementation passed to {@link Service#create} performing a service request on network level, i.e. by utilizing http requests or websockets.
  * @param method Reflected or static method being called
  * @param requestData Request data
  * @param callback Callback function
  */
-type RPCImpl = (method: (Method|rpc.ServiceMethod<Message<{}>, Message<{}>>), requestData: Uint8Array, callback: RPCImplCallback) => void;
+type RPCImpl = RPCUnaryCall;
 
 /**
  * Node-style callback as used by {@link RPCImpl}.
@@ -1397,7 +1407,7 @@ export class Service extends NamespaceBase {
      * @param [responseDelimited=false] Whether responses are length-delimited
      * @returns RPC service. Useful where requests and/or responses are streamed.
      */
-    public create(rpcImpl: RPCImpl, requestDelimited?: boolean, responseDelimited?: boolean): rpc.Service;
+    public create(rpcImpl: RPCImpl | RPCHandler, requestDelimited?: boolean, responseDelimited?: boolean): rpc.Service;
 }
 
 /** Service descriptor. */

--- a/index.d.ts
+++ b/index.d.ts
@@ -1342,14 +1342,44 @@ export namespace rpc {
 }
 
 type RPCUnaryCall = (method: (Method|rpc.ServiceMethod<Message<{}>, Message<{}>>), requestData: Uint8Array, callback: RPCImplCallback) => void;
-type RPCStreamingCall = (method: (Method|rpc.ServiceMethod<Message<{}>, Message<{}>>), requestData: Uint8Array, responseFn: (responseData: Uint8Array) => protobuf.Message) => util.EventEmitter;
+// TODO: check if all args are valid
+type RPCServerStreamCall = (method: (Method|rpc.ServiceMethod<Message<{}>, Message<{}>>), requestData: Uint8Array, responseFn: (responseData: Uint8Array) => protobuf.Message) => util.EventEmitter;
+type RPCClientStreamCall = (method: (Method|rpc.ServiceMethod<Message<{}>, Message<{}>>), requestFn: (requestData: Uint8Array) => protobuf.Message, responseFn: (responseData: Uint8Array) => protobuf.Message) => util.EventEmitter;
+type RPCBidiStreamCall = (method: (Method|rpc.ServiceMethod<Message<{}>, Message<{}>>), requestFn: (requestData: Uint8Array) => protobuf.Message, responseFn: (responseData: Uint8Array) => protobuf.Message) => util.EventEmitter;
 
 /**
  * RPCHandler allows to pass custom RPC implementation for unary and streaming calls
  */
 export interface RPCHandler {
     unaryCall: RPCUnaryCall;
-    streamingCall: RPCStreamingCall;
+    serverStreamCall: RPCServerStreamCall;
+    clientStreamCall: RPCClientStreamCall;
+    bidiStreamCall: RPCBidiStreamCall;
+}
+
+export interface RPCBidiStream<T, U = {}> {
+    on(evt: 'recv', fn: (data: U) => any, ctx?: any): util.EventEmitter;
+    on(evt: 'error', fn: (data: any) => any, ctx?: any): util.EventEmitter;
+    on(evt: 'end', fn: (data: any) => any, ctx?: any): util.EventEmitter;
+    // TODO: handle off event
+    off(evt?: string, fn?: () => any): util.EventEmitter;
+    emit(evt: 'send', data: T): util.EventEmitter;
+}
+
+export interface RPCServerStream<T> {
+    on(evt: 'recv', fn: (data: T) => any, ctx?: any): util.EventEmitter;
+    on(evt: 'error', fn: (data: any) => any, ctx?: any): util.EventEmitter;
+    on(evt: 'end', fn: (data: any) => any, ctx?: any): util.EventEmitter;
+    // TODO: handle off event
+    off(evt?: string, fn?: () => any): util.EventEmitter;
+}
+
+export interface RPCClientStream<T> {
+    on(evt: 'error', fn: (data: any) => any, ctx?: any): util.EventEmitter;
+    on(evt: 'end', fn: (data: any) => any, ctx?: any): util.EventEmitter;
+    // TODO: handle off event
+    off(evt?: string, fn?: () => any): util.EventEmitter;
+    emit(evt: 'send', value: T): util.EventEmitter;
 }
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -1342,7 +1342,7 @@ export namespace rpc {
 }
 
 type RPCUnaryCall = (method: (Method|rpc.ServiceMethod<Message<{}>, Message<{}>>), requestData: Uint8Array, callback: RPCImplCallback) => void;
-type RPCStreamingCall = (method: (Method|rpc.ServiceMethod<Message<{}>, Message<{}>>), requestData: Uint8Array, responseFn: (responseData: Uint8Array) => protobuf.Message): util.EventEmitter;
+type RPCStreamingCall = (method: (Method|rpc.ServiceMethod<Message<{}>, Message<{}>>), requestData: Uint8Array, responseFn: (responseData: Uint8Array) => protobuf.Message) => util.EventEmitter;
 
 /**
  * RPCHandler allows to pass custom RPC implementation for unary and streaming calls

--- a/src/rpc/service.js
+++ b/src/rpc/service.js
@@ -40,9 +40,12 @@ var util = require("../util/minimal");
  * @param {boolean} [responseDelimited=false] Whether responses are length-delimited
  */
 function Service(rpcImpl, requestDelimited, responseDelimited) {
-
-    if (typeof rpcImpl !== "function")
+    
+    if (typeof rpcImpl !== "object" && typeof rpcImpl !== "function") {
         throw TypeError("rpcImpl must be a function");
+    } else if (typeof rpcImpl === "object" && (typeof rpcImpl.unaryCall !== "function" || typeof rpcImpl.streamingCall !== "function")) {
+        throw TypeError("rpcImpl should implement RPCHandler")
+    }
 
     util.EventEmitter.call(this);
 
@@ -77,7 +80,6 @@ function Service(rpcImpl, requestDelimited, responseDelimited) {
  * @template TRes extends Message<TRes>
  */
 Service.prototype.rpcCall = function rpcCall(method, requestCtor, responseCtor, request, callback) {
-
     if (!request)
         throw TypeError("request must be specified");
 
@@ -85,13 +87,17 @@ Service.prototype.rpcCall = function rpcCall(method, requestCtor, responseCtor, 
     if (!callback)
         return util.asPromise(rpcCall, self, method, requestCtor, responseCtor, request);
 
-    if (!self.rpcImpl) {
+    var rpcUnaryImpl = self.rpcImpl;
+    if (typeof rpcUnaryImpl.unaryCall === "function") {
+        rpcUnaryImpl = rpcUnaryImpl.unaryCall;
+    }
+    if (!rpcUnaryImpl) {
         setTimeout(function() { callback(Error("already ended")); }, 0);
         return undefined;
     }
 
     try {
-        return self.rpcImpl(
+        return rpcUnaryImpl(
             method,
             requestCtor[self.requestDelimited ? "encodeDelimited" : "encode"](request).finish(),
             function rpcCallback(err, response) {
@@ -124,6 +130,33 @@ Service.prototype.rpcCall = function rpcCall(method, requestCtor, responseCtor, 
         setTimeout(function() { callback(err); }, 0);
         return undefined;
     }
+};
+
+/**
+ * Calls a service method through {@link rpc.Service#rpcStreamingImpl|rpcStreamingImpl}.
+ * @param {Method|rpc.ServiceMethod<TReq,TRes>} method Reflected or static method
+ * @param {Constructor<TReq>} requestCtor Request constructor
+ * @param {Constructor<TRes>} responseCtor Response constructor
+ * @param {TReq|Properties<TReq>} request Request message or plain object
+ * @returns {undefined}
+ */
+Service.prototype.rpcStreamingCall = function rpcStreamingCall(method, requestCtor, responseCtor, request) {
+    if (!request)
+        throw TypeError("request must be specified");
+
+    var self = this;
+
+    if (typeof self.rpcImpl.streamingCall !== "function") {
+        throw new Error("rpcImpl should implement RPCHandler to support streaming");
+    }
+
+    return self.rpcImpl.streamingCall(
+        method,
+        requestCtor[self.requestDelimited ? "encodeDelimited" : "encode"](request).finish(),
+        function responseFn (response) {
+            return responseCtor[self.responseDelimited ? "decodeDelimited" : "decode"](response);
+        }
+    );
 };
 
 /**


### PR DESCRIPTION
This PR will add possibility to implement server, client, bidirectional streams. Currently it is missing some more testing, but server streaming is already working.

Server stream:
```ts
serverStream = () => {
    const { grpcService } = this.props;
    const stream = grpcService.serverStream({ message: `Ping ${utcNow()}` });
    stream.on('recv', (data) => {
        console.log('data', data);
    });
    stream.on('error', (err) => {
        console.log('error', err);
    });
    stream.on('end', () => {
        console.log('end');
    });
}
```

Client stream:
```ts
clientStream = () => {
    const { grpcService } = this.props;
    const stream = grpcService.clientStream();
    stream.emit('send', { message: `Ping ${utcNow()}` });
    stream.on('error', (err) => {
        console.log('error', err);
    });
    stream.on('end', () => {
        console.log('end');
    });
}
```

Bidirectional stream:
```ts
bidiStream = () => {
    const { grpcService } = this.props;
    const stream = grpcService.bidiStream();
    stream.emit('send', { message: `Ping ${utcNow()}` });
    stream.on('recv', (data) => {
        console.log('data', data);
    });
    stream.on('error', (err) => {
        console.log('error', err);
    });
    stream.on('end', () => {
        console.log('end');
    });
}
```

It is possible to pass `RPCHandler` implementation to handle all these streams + existing unary calls.

```ts
createService<T extends rpc.Service>(name: string, service: typeof rpc.Service): T {
    const rpcHandler: RPCHandler = {
        unaryCall: this._createRcpUnaryImpl(name),
        serverStreamCall: this._createServerStreamImpl(name),
        clientStreamCall: this._createClientStreamImpl(name),
        bidiStreamCall: this._createBidiStreamImpl(name)
    };
    return new service(rpcHandler) as T;
}
``` 

Some examples from my actual implementation using underlying EvenEmitter. (My personal use cases are more complex since I use React Native and native SwiftGrpc):

```ts
// For simple unary calls it works as is
private _createRcpUnaryImpl(serviceName: string): RPCUnaryCall {
    return (method, requestData, callback) => {
        if (!requestData) {
            return;
        }
        const methodName = `/${serviceName}/${method.name}`;
        const reqBase64String = Buffer.from(requestData).toString('base64');
        this.grpcNative.makeUnaryCall(methodName, reqBase64String).then((rspBase64Sring) => {
            const rspBytes = Buffer.from(rspBase64Sring, 'base64');
            callback(null, rspBytes);
        }, (err) => {
            callback(err, null);
        });
    };
}

// For streaming calls we return event emmiter
private _createServerStreamImpl(serviceName: string): RPCServerStreamCall {
    return (method, requestData, responseFn) => {
        const methodName = `/${serviceName}/${method.name}`;
        let h = this._streamingHandlers.get(methodName);
        if (h) {
            return h.emitter;
        }
        h = { emitter: new util.EventEmitter(), responseFn };
        this._streamingHandlers.set(methodName, h);

        const reqBase64String = Buffer.from(requestData).toString('base64');
        this.grpcNative.makeStreamingServerCall(methodName, reqBase64String).catch((err) => {
            h.emitter.emit('error', err);
            h.emitter.emit('end', true);
        });
        return h.emitter;
    };
}

// client, bidi comming soon
```