### PR TITLE
Treat second part of a reserved range as exclusive

### DIFF
--- a/src/namespace.js
+++ b/src/namespace.js
@@ -62,7 +62,7 @@ Namespace.arrayToJSON = arrayToJSON;
 Namespace.isReservedId = function isReservedId(reserved, id) {
     if (reserved)
         for (var i = 0; i < reserved.length; ++i)
-            if (typeof reserved[i] !== "string" && reserved[i][0] <= id && reserved[i][1] >= id)
+            if (typeof reserved[i] !== "string" && reserved[i][0] <= id && reserved[i][1] > id)
                 return true;
     return false;
 };


### PR DESCRIPTION
Reserved ranges on a namespace level are exclusive in their second element: https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/descriptor.proto#L119