### PR TITLE
Add test case where parse, tokenizer fails with empty option

### DIFF
--- a/tests/comp_option.js
+++ b/tests/comp_option.js
@@ -1,0 +1,25 @@
+var tape = require('tape');
+
+var protobuf = require('..');
+
+var proto =
+  'syntax = "proto3";\
+package myservice;\
+message DoSomethingRequest {\
+}\
+message DoSomethingResponse {\
+}\
+service MyService {\
+  rpc DoSomething(DoSomethingRequest) returns (DoSomethingResponse) {\
+    option (google.api.http) = {\
+      // Some TODO comment \
+    };\
+  };\
+}';
+
+tape.test('option', function(test) {
+  var root = protobuf.parse(proto).root;
+  root.resolveAll();
+  test.pass('should parse and resolve without errors');
+  test.end();
+});


### PR DESCRIPTION
I don't have a fix just yet, trying to understand the code first, but wanted to open this PR for any guidance on the correct place to fix this test case. My application is interacting with a service that has an empty option therefore the parser fails. I figured his library should fail gracefully if the user has not set any option.

It seems the best place to fix this would be in the parse.js file in the `parseOption > parseOptionValue` on line 561 and 564.