### PR TITLE
Fix nested imports with `--sparse` flag

### DIFF
--- a/cli/pbjs.js
+++ b/cli/pbjs.js
@@ -252,10 +252,16 @@ exports.main = function main(args, callback) {
         if (tobj.fieldsArray)
             tobj.fieldsArray.forEach(function(fobj) {
                 fobj.referenced = true;
+
+                if (fobj.resolvedType)
+                    util.traverse(fobj.resolvedType, markReferenced);
             });
         if (tobj.oneofsArray)
             tobj.oneofsArray.forEach(function(oobj) {
                 oobj.referenced = true;
+
+                if (oobj.resolvedType)
+                    util.traverse(oobj.resolvedType, markReferenced);
             });
         // also mark an extension field's extended type, but not its (other) fields
         if (tobj.extensionField)


### PR DESCRIPTION
Using message types from files imported more than one level deep fails to mark the imported messages as "referenced" when pruning nodes with the `--sparse` flag.

This can be reproduced with some simple proto definitions:

```
// parent.proto
import "child.proto";

message Parent {
    optional Child child = 1;
}
```

```
// child.proto
import "grandchild.proto";

message Child {
    optional Grandchild grandchild = 1;
}
```

```
// grandchild.proto
message Grandchild {
    optional string name = 1;
}
```

Using the `pbjs` command on `parent.proto` with the `--sparse` flag, you would expect `Parent`, `Child`, and `Grandchild` classes to be generated, since they are all directly or indirectly referenced from `parent.proto`:

```
npx pbjs --sparse --target static-module --wrap es6 --out protos.js parent.proto
```

However, the generated JS file is missing the `Grandchild` class. The `Child` class references it as `$rootGrandChild` (which doesn't exist) instead of the expected `$root.Grandchild`. Additionally, the JSDoc comments reference the `Irandchild` type instead of `IGrandchild`; this breaks the TypeScript definitions generated from `pbts`.

Adding the other proto files to the `pbjs` command works but isn't maintainable when you have hundreds of proto definitions (that's what `import` is for anyway).

This PR fixes this issue by traversing the resolved type of all fields referenced by a main file.